### PR TITLE
Fix: Player fails to initialize on macOS — hardcoded `libc.so.6

### DIFF
--- a/src/ytm_player/services/player.py
+++ b/src/ytm_player/services/player.py
@@ -83,8 +83,15 @@ class Player:
         # mpv segfaults if LC_NUMERIC is not C.  Textual's async runtime
         # resets locale, so we must force it immediately before mpv init.
         import ctypes
+        import ctypes.util
+        import sys
 
-        _libc = ctypes.CDLL("libc.so.6")
+        _libc_name = (
+            "libSystem.B.dylib"
+            if sys.platform == "darwin"
+            else ctypes.util.find_library("c") or "libc.so.6"
+        )
+        _libc = ctypes.CDLL(_libc_name)
         _libc.setlocale.restype = ctypes.c_char_p
         _libc.setlocale.argtypes = [ctypes.c_int, ctypes.c_char_p]
         _libc.setlocale(locale.LC_NUMERIC, b"C")


### PR DESCRIPTION
## Problem

On macOS, launching `ytm` shows:

> Could not start player services. Make sure mpv is installed and in your PATH.

This happens even when `mpv` is correctly installed and `import mpv` works fine in Python.

The root cause is in `Player._init_mpv()` — the `LC_NUMERIC` locale fix uses a hardcoded `ctypes.CDLL("libc.so.6")`, which is the Linux-specific name for the C standard library. On macOS this file doesn't exist (`libSystem.B.dylib` is the equivalent), so the constructor raises an `OSError`. The broad `except Exception` in `on_mount()` catches it and shows the misleading mpv error message.

## Fix

Replace the hardcoded library name with platform-aware detection:

- **macOS** (`sys.platform == "darwin"`) → `libSystem.B.dylib`
- **Other platforms** → `ctypes.util.find_library("c")` with fallback to `libc.so.6`

## Testing

Verified on macOS 15 (Apple Silicon) with mpv 0.41.0 and Python 3.13:
- `Player()` initializes successfully
- `is_healthy` returns `True`
- Playback works end-to-end in the TUI

No behavior change on Linux — `ctypes.util.find_library("c")` resolves to `libc.so.6` there, and the hardcoded fallback is kept as a safety net.