### PR TITLE
fix: normalize radio tracks and fix browse home item routing

### DIFF
--- a/src/ytm_player/app.py
+++ b/src/ytm_player/app.py
@@ -462,9 +462,10 @@ class YTMPlayerApp(App):
 
         # Restore queue from last session (before enabling shuffle so the
         # shuffle order is built from a populated queue).
+        from ytm_player.utils.formatting import normalize_tracks
         saved_tracks = state.get("queue_tracks", [])
         if saved_tracks and isinstance(saved_tracks, list):
-            self.queue.add_multiple(saved_tracks)
+            self.queue.add_multiple(normalize_tracks(saved_tracks))
             saved_index = state.get("queue_index", 0)
             if isinstance(saved_index, int) and 0 <= saved_index < len(saved_tracks):
                 self.queue.jump_to(saved_index)
@@ -1090,12 +1091,12 @@ class YTMPlayerApp(App):
             )
             return
 
-        video_id = track.get("video_id", "")
+        video_id = get_video_id(track)
         if not video_id:
             self._consecutive_failures += 1
             title = track.get("title", "Unknown")
             self.notify(
-                f'Skipping "{title}" — no video ID (may require Premium).',
+                f'Skipping "{title}" — no video ID (AI-generated streams are not supported).',
                 severity="warning",
                 timeout=3,
             )
@@ -1278,7 +1279,8 @@ class YTMPlayerApp(App):
 
         self.notify("Loading radio suggestions...", timeout=3)
         try:
-            radio_tracks = await self.ytmusic.get_radio(video_id)
+            from ytm_player.utils.formatting import normalize_tracks
+            radio_tracks = normalize_tracks(await self.ytmusic.get_radio(video_id))
             if radio_tracks:
                 self.queue.set_radio_tracks(radio_tracks)
                 next_track = self.queue.next_track()
@@ -1712,7 +1714,8 @@ class YTMPlayerApp(App):
 
         self.notify("Starting radio...", timeout=3)
         try:
-            radio_tracks = await self.ytmusic.get_radio(video_id)
+            from ytm_player.utils.formatting import normalize_tracks
+            radio_tracks = normalize_tracks(await self.ytmusic.get_radio(video_id))
         except Exception:
             logger.exception("Failed to start radio")
             self.notify("Failed to start radio", severity="error")

--- a/src/ytm_player/ui/pages/browse.py
+++ b/src/ytm_player/ui/pages/browse.py
@@ -742,9 +742,10 @@ class BrowsePage(Widget):
 
     async def _navigate_item(self, item: dict[str, Any]) -> None:
         """Route an item to the appropriate context page or play it directly."""
-        result_type = item.get("resultType", item.get("type", ""))
+        result_type = (item.get("resultType") or item.get("type") or "").lower()
         video_id = get_video_id(item)
         browse_id = item.get("browseId")
+        playlist_id = item.get("playlistId") or item.get("audioPlaylistId")
 
         if result_type in ("song", "video", "flat_song") or video_id:
             await self.app.play_track(item)
@@ -755,11 +756,19 @@ class BrowsePage(Widget):
             if browse_id:
                 await self.app.navigate_to("context", context_type="artist", context_id=browse_id)
         elif result_type == "playlist":
-            playlist_id = item.get("playlistId") or browse_id
-            if playlist_id:
+            if playlist_id or browse_id:
                 await self.app.navigate_to(
-                    "context", context_type="playlist", context_id=playlist_id
+                    "context", context_type="playlist", context_id=playlist_id or browse_id
                 )
+        elif playlist_id:
+            # Shelves like "Mixed for you", "Listen again" radio entries, mixes etc.
+            # have a playlistId but no resultType.
+            await self.app.navigate_to(
+                "context", context_type="playlist", context_id=playlist_id
+            )
+        elif browse_id:
+            # Fallback: treat any remaining browseId as an album/playlist context.
+            await self.app.navigate_to("context", context_type="album", context_id=browse_id)
 
     # ------------------------------------------------------------------
     # Vim-style action handler


### PR DESCRIPTION
## Problem

Several types of items on the Browse/Home page (Listen Again, Mixed for you, radio mixes) were silently unresponsive when clicked. Three separate root causes:

### 1. Case mismatch in `_navigate_item` (browse.py)
`resultType` values from the API like `'Album'`, `'Playlist'` were compared against lowercase string literals (`'album'`, `'playlist'`) with no `.lower()` normalisation — so the comparison always failed and falls fell through to a no-op.

### 2. Missing `playlistId`-only branch (browse.py)
Many home shelf items (Listen Again radio, Mixed for you, contextual mixes) have only a `playlistId` / `audioPlaylistId` and no `resultType` or `browseId`. The router had no branch for these so they were silently ignored.

### 3. `play_track` ignoring camelCase `videoId` (app.py)
Home shelf track objects use `videoId` (camelCase, the raw API format) rather than `video_id` (snake_case, the normalised format). `play_track` called `track.get("video_id", "")`, which always returned `""` for these items, triggering the "no video ID" early-return and silently skipping playback.

### 4. Un-normalised radio / session-restore tracks (app.py)
`get_radio()` results and saved session queue tracks could contain un-normalised dicts (camelCase keys, missing fields) that wound up in the queue without `normalize_tracks()` being applied.

## Solution

**`src/ytm_player/ui/pages/browse.py`**
- Normalise `result_type` to lowercase before comparisons.
- Extract `playlist_id = item.get("playlistId") or item.get("audioPlaylistId")` upfront.
- Add `elif playlist_id:` branch that calls `app.browse_playlist(playlist_id)`.
- Add `elif browse_id:` fallback catch-all.

**`src/ytm_player/app.py`**
- `play_track`: use `get_video_id(track)` (handles both `videoId` and `video_id`) instead of `track.get("video_id", "")`.
- Two radio call sites: wrap `get_radio()` result in `normalize_tracks()`.
- Session queue restore: wrap loaded `saved_tracks` in `normalize_tracks()`.

## Changes

- `src/ytm_player/ui/pages/browse.py`
- `src/ytm_player/app.py`