### PR TITLE
feat: move theme setting to config.toml [ui] section

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ js_runtimes = ""             # Optional: bun or bun:/path/to/bun (also node/quic
 
 [ui]
 album_art = true
+theme = "ytm-dark"           # Textual theme name (e.g. catppuccin-mocha, dracula, nord, tokyo-night)
 progress_style = "block"     # block or line
 sidebar_width = 30
 col_index = 4                # 0 = auto-fill

--- a/src/ytm_player/app/_app.py
+++ b/src/ytm_player/app/_app.py
@@ -170,6 +170,10 @@ class YTMPlayerApp(
         # Clean exit flag: True when user quits via q/C-q (no resume on next start).
         self._clean_exit: bool = False
 
+        # Set to True once session restore is complete so watch_theme knows when
+        # to persist user-initiated theme changes back to config.toml.
+        self._theme_initialized: bool = False
+
         # Sidebar state: per-page playlist sidebar visibility and global lyrics toggle.
         # Default True for all pages -- user can toggle off per-view.
         self._sidebar_default: bool = True
@@ -238,6 +242,16 @@ class YTMPlayerApp(
             self.theme_colors = tc
         except Exception:
             pass
+
+        # Persist user-initiated theme changes to config.toml so it remains
+        # the source of truth.  Skip during startup (before session restore
+        # completes) to avoid overwriting the user's configured value.
+        if self._theme_initialized:
+            try:
+                self.settings.ui.theme = theme_name
+                self.settings.save()
+            except Exception:
+                logger.debug("Failed to persist theme to config.toml", exc_info=True)
 
     # ── Compose ──────────────────────────────────────────────────────
 

--- a/src/ytm_player/app/_app.py
+++ b/src/ytm_player/app/_app.py
@@ -246,7 +246,7 @@ class YTMPlayerApp(
         # Persist user-initiated theme changes to config.toml so it remains
         # the source of truth.  Skip during startup (before session restore
         # completes) to avoid overwriting the user's configured value.
-        if self._theme_initialized:
+        if getattr(self, "_theme_initialized", False):
             try:
                 self.settings.ui.theme = theme_name
                 self.settings.save()

--- a/src/ytm_player/app/_app.py
+++ b/src/ytm_player/app/_app.py
@@ -107,6 +107,9 @@ class YTMPlayerApp(
     def __init__(self) -> None:
         super().__init__()
 
+        # Must be set before self.theme so watch_theme doesn't fire prematurely.
+        self._theme_initialized: bool = False
+
         # Register custom YTM theme and set as default.
         from ytm_player.ui.theme import YTM_DARK
 
@@ -169,10 +172,6 @@ class YTMPlayerApp(
 
         # Clean exit flag: True when user quits via q/C-q (no resume on next start).
         self._clean_exit: bool = False
-
-        # Set to True once session restore is complete so watch_theme knows when
-        # to persist user-initiated theme changes back to config.toml.
-        self._theme_initialized: bool = False
 
         # Sidebar state: per-page playlist sidebar visibility and global lyrics toggle.
         # Default True for all pages -- user can toggle off per-view.
@@ -246,7 +245,7 @@ class YTMPlayerApp(
         # Persist user-initiated theme changes to config.toml so it remains
         # the source of truth.  Skip during startup (before session restore
         # completes) to avoid overwriting the user's configured value.
-        if getattr(self, "_theme_initialized", False):
+        if self._theme_initialized:
             try:
                 self.settings.ui.theme = theme_name
                 self.settings.save()

--- a/src/ytm_player/app/_session.py
+++ b/src/ytm_player/app/_session.py
@@ -69,8 +69,10 @@ class SessionMixin:
         # Always start with lyrics sidebar closed regardless of previous session.
         self._lyrics_sidebar_open = False
 
-        # Restore Textual theme from last session.
-        saved_theme = state.get("theme")
+        # Restore Textual theme: config.toml is the source of truth; session.json
+        # overrides it when the user changed the theme at runtime.
+        config_theme = self.settings.ui.theme
+        saved_theme = state.get("theme", config_theme)
         if saved_theme and isinstance(saved_theme, str):
             try:
                 self.theme = saved_theme

--- a/src/ytm_player/app/_session.py
+++ b/src/ytm_player/app/_session.py
@@ -69,15 +69,17 @@ class SessionMixin:
         # Always start with lyrics sidebar closed regardless of previous session.
         self._lyrics_sidebar_open = False
 
-        # Restore Textual theme: config.toml is the source of truth; session.json
-        # overrides it when the user changed the theme at runtime.
+        # Apply theme from config.toml — the single source of truth.
+        # User-initiated changes (Ctrl+P) are written back to config.toml via
+        # watch_theme, so session.json no longer needs to store the theme.
         config_theme = self.settings.ui.theme
-        saved_theme = state.get("theme", config_theme)
-        if saved_theme and isinstance(saved_theme, str):
+        if config_theme and isinstance(config_theme, str):
             try:
-                self.theme = saved_theme
+                self.theme = config_theme
             except Exception:
                 pass
+
+        self._theme_initialized = True
 
         # Restore transliteration toggle state (session overrides config).
         if "transliteration_enabled" in state:
@@ -153,7 +155,6 @@ class SessionMixin:
             "sidebar_per_page": self._sidebar_per_page,
             "lyrics_sidebar_open": self._lyrics_sidebar_open,
             "transliteration_enabled": self._get_transliteration_state(),
-            "theme": self.theme,
         }
         try:
             from ytm_player.config.paths import SECURE_FILE_MODE, secure_chmod

--- a/src/ytm_player/config/settings.py
+++ b/src/ytm_player/config/settings.py
@@ -65,6 +65,7 @@ class UISettings:
     col_album: int = 0
     col_duration: int = 8
     bidi_mode: str = "auto"  # "auto", "reorder", "passthrough"
+    theme: str = ""  # Textual theme name (e.g. "catppuccin-mocha"); empty = Textual default
 
 
 @dataclass

--- a/src/ytm_player/config/settings.py
+++ b/src/ytm_player/config/settings.py
@@ -65,7 +65,7 @@ class UISettings:
     col_album: int = 0
     col_duration: int = 8
     bidi_mode: str = "auto"  # "auto", "reorder", "passthrough"
-    theme: str = ""  # Textual theme name (e.g. "catppuccin-mocha"); empty = Textual default
+    theme: str = "ytm-dark"
 
 
 @dataclass


### PR DESCRIPTION
Closes #33

## Summary

- Adds `theme` field to `UISettings` in `config/settings.py` (default: `"ytm-dark"`) so users can set their preferred Textual theme in `config.toml` under `[ui]`:
  ```toml
  [ui]
  theme = "catppuccin-mocha"
  ```
- `config.toml` is the single source of truth in both directions: on startup the theme is read from config, and when the user changes the theme at runtime (Ctrl+P), `watch_theme` writes the new value back to `config.toml` immediately.
- `session.json` no longer stores the theme key.
- A `_theme_initialized` flag prevents `watch_theme` from overwriting config during startup (before session restore completes).
- README `[ui]` section updated to document the new setting.

## Test plan

- [x] Set `theme = "catppuccin-mocha"` in `[ui]` section of `config.toml`, start the app — theme applies on startup
- [x] Change theme via Ctrl+P at runtime — `config.toml` is updated immediately, `session.json` does NOT store the theme
- [x] Quit and restart — theme persists from `config.toml`
- [x] Fresh install (no config.toml) — config is created with `theme = "ytm-dark"` as default
- [x] Existing config without `theme` key — app uses `"ytm-dark"` in memory; key appears in config on first theme change

🤖 Generated with [Claude Code](https://claude.com/claude-code)