### PR TITLE
feat: user-defined themes via themes/ directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A full-featured YouTube Music player for the terminal. Browse your library, sear
 - **Vim-style navigation** — `j`/`k` movement, multi-key sequences (`g l` for library, `g s` for search), count prefixes (`5j`)
 - **Table sorting** — click column headers or use keyboard (`s t`/`s a`/`s A`/`s d`/`s r`), drag-to-resize columns
 - **Predictive search** — debounced with 300ms delay, music-first mode with clickable toggle to all results
-- **Theming** — 18 built-in Textual themes (nord, dracula, gruvbox, catppuccin, etc.) via `Ctrl+P`, plus custom app-specific color overrides in `theme.toml`. Theme selection persists across sessions
+- **Theming** — 18 built-in Textual themes (nord, dracula, gruvbox, catppuccin, etc.) via `Ctrl+P`, plus user-defined themes in `themes/`. Theme selection persists across sessions
 - **Session resume** — restores queue position, volume, shuffle/repeat state, theme on startup
 - **Free-tier support** — works with free YouTube Music accounts (Premium-only tracks are filtered with notice)
 - **Multi-account & Brand Account support** — `ytm setup` auto-detects multiple Google accounts; Brand Accounts configurable via `brand_account_id` in config
@@ -382,7 +382,7 @@ Config files live in `~/.config/ytm-player/` (respects `$XDG_CONFIG_HOME`):
 |------|---------|
 | `config.toml` | General settings, playback, cache, UI |
 | `keymap.toml` | Custom keybinding overrides |
-| `theme.toml` | Color scheme customization |
+| `themes/` | User-defined custom themes |
 | `auth.json` | YouTube Music credentials (auto-generated) |
 
 Open config directory in your editor:
@@ -443,21 +443,31 @@ session_key = ""
 username = ""
 ```
 
-### Example `theme.toml`
+### Custom themes
 
-Base colors (primary, background, etc.) come from the active Textual theme — switch themes with `Ctrl+P`. The `theme.toml` file overrides app-specific colors only:
+Drop `.toml` files in the `themes/` config directory to define your own themes. They appear in the `Ctrl+P` picker alongside the built-in Textual themes.
+
+Only `name` and `primary` are required — Textual derives the full palette automatically:
 
 ```toml
-[colors]
-playback_bar_bg = "#1a1a1a"
-selected_item = "#2a2a2a"
-progress_filled = "#ff0000"
-progress_empty = "#555555"
-lyrics_played = "#999999"
-lyrics_current = "#2ecc71"
-lyrics_upcoming = "#aaaaaa"
-active_tab = "#ffffff"
-inactive_tab = "#999999"
+name    = "my-theme"
+primary = "#cba6f7"
+```
+
+You can also specify the full palette and override ytm-player-specific colors via `[variables]`:
+
+```toml
+name       = "my-theme"
+primary    = "#cba6f7"
+background = "#1e1e2e"
+surface    = "#313244"
+dark       = true
+
+[variables]
+playback-bar-bg = "#181825"
+progress-filled = "#cba6f7"
+progress-empty  = "#45475a"
+lyrics-current  = "#a6e3a1"
 ```
 
 ## Spotify Import

--- a/README.md
+++ b/README.md
@@ -459,15 +459,26 @@ You can also specify the full palette and override ytm-player-specific colors vi
 ```toml
 name       = "my-theme"
 primary    = "#cba6f7"
+secondary  = "#aaaaaa"
+accent     = "#b07ad4"
+success    = "#a6e3a1"
+warning    = "#f9e2af"
+error      = "#f38ba8"
+foreground = "#cdd6f4"
 background = "#1e1e2e"
 surface    = "#313244"
 dark       = true
 
 [variables]
 playback-bar-bg = "#181825"
+active-tab      = "#cdd6f4"
+inactive-tab    = "#6c7086"
+selected-item   = "#45475a"
 progress-filled = "#cba6f7"
 progress-empty  = "#45475a"
+lyrics-played   = "#6c7086"
 lyrics-current  = "#a6e3a1"
+lyrics-upcoming = "#cdd6f4"
 ```
 
 ## Spotify Import

--- a/src/ytm_player/app/_app.py
+++ b/src/ytm_player/app/_app.py
@@ -107,10 +107,7 @@ class YTMPlayerApp(
     def __init__(self) -> None:
         super().__init__()
 
-        # Register custom YTM theme and set as default.
-        from ytm_player.ui.theme import YTM_DARK
-
-        self.register_theme(YTM_DARK)
+        self._register_themes()
         self.theme = "ytm-dark"
 
         # Configuration.
@@ -203,6 +200,13 @@ class YTMPlayerApp(
 
         return variables
 
+    def _register_themes(self) -> None:
+        """Register ytm-dark and any user-defined themes from themes/."""
+        from ytm_player.ui.theme import YTM_DARK, load_user_themes
+
+        for theme in [YTM_DARK, *load_user_themes()]:
+            self.register_theme(theme)
+
     def watch_theme(self, theme_name: str) -> None:
         """Rebuild ThemeColors when the Textual theme changes."""
         from ytm_player.ui.theme import ThemeColors, set_theme
@@ -233,7 +237,6 @@ class YTMPlayerApp(
                 lyrics_current=v.get("lyrics-current", t.success or "#2ecc71"),
                 lyrics_upcoming=v.get("lyrics-upcoming", t.foreground or "#aaaaaa"),
             )
-            tc._apply_toml_overrides()
             set_theme(tc)
             self.theme_colors = tc
         except Exception:

--- a/src/ytm_player/config/paths.py
+++ b/src/ytm_player/config/paths.py
@@ -64,7 +64,7 @@ else:
     IPC_PORT_FILE = None  # Not used on Unix.
 
 KEYMAP_FILE = CONFIG_DIR / "keymap.toml"
-THEME_FILE = CONFIG_DIR / "theme.toml"
+THEMES_DIR = CONFIG_DIR / "themes"
 RECENT_PLAYLISTS_FILE = CONFIG_DIR / "recent_playlists.json"
 SESSION_STATE_FILE = CONFIG_DIR / "session.json"
 HISTORY_DB = CONFIG_DIR / "history.db"
@@ -89,7 +89,7 @@ def ensure_dirs() -> None:
     global _dirs_ensured
     if _dirs_ensured:
         return
-    for _dir in (CONFIG_DIR, CACHE_DIR):
+    for _dir in (CONFIG_DIR, CACHE_DIR, THEMES_DIR):
         _dir.mkdir(parents=True, exist_ok=True)
         secure_chmod(_dir, SECURE_DIR_MODE)
     _dirs_ensured = True

--- a/src/ytm_player/ui/theme.py
+++ b/src/ytm_player/ui/theme.py
@@ -2,28 +2,16 @@
 
 from __future__ import annotations
 
+import logging
 import tomllib
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Self
 
 from textual.theme import Theme
 
-from ytm_player.config.paths import THEME_FILE
+from ytm_player.config.paths import THEMES_DIR
 
-# ── App-specific CSS variable names (not provided by Textual themes) ───
-
-_APP_VARS = (
-    "playback_bar_bg",
-    "active_tab",
-    "inactive_tab",
-    "selected_item",
-    "progress_filled",
-    "progress_empty",
-    "lyrics_played",
-    "lyrics_current",
-    "lyrics_upcoming",
-)
+logger = logging.getLogger(__name__)
 
 # ── YTM dark theme — YouTube Music-inspired defaults ──────────────────
 
@@ -57,8 +45,10 @@ YTM_DARK = Theme(
 class ThemeColors:
     """Resolved color values for Rich Text rendering in widget render() methods.
 
-    Base colors come from the active Textual theme.  App-specific colors
-    can be overridden via ``theme.toml``.
+    Populated from the active Textual theme via watch_theme.  App-specific
+    variables (playback bar, lyrics, etc.) are read from the theme's
+    ``variables`` dict, which user themes can set in their ``[variables]``
+    section.
     """
 
     # Base colors (populated from Textual theme at runtime).
@@ -75,7 +65,7 @@ class ThemeColors:
     muted_text: str = "#999999"
     text: str = "#ffffff"
 
-    # App-specific colors (customisable via theme.toml).
+    # App-specific colors (set from theme variables dict).
     playback_bar_bg: str = "#1a1a1a"
     active_tab: str = "#ffffff"
     inactive_tab: str = "#999999"
@@ -86,98 +76,67 @@ class ThemeColors:
     lyrics_current: str = "#2ecc71"
     lyrics_upcoming: str = "#aaaaaa"
 
-    @classmethod
-    def from_css_variables(cls, variables: dict[str, str]) -> Self:
-        """Build ThemeColors from resolved Textual CSS variables.
 
-        Maps Textual's variable names to our field names and applies any
-        app-specific overrides from ``theme.toml``.
-        """
-        tc = cls(
-            background=variables.get("background", cls.background),
-            foreground=variables.get("foreground", cls.foreground),
-            primary=variables.get("primary", cls.primary),
-            secondary=variables.get("secondary", cls.secondary),
-            accent=variables.get("accent", cls.accent),
-            success=variables.get("success", cls.success),
-            warning=variables.get("warning", cls.warning),
-            error=variables.get("error", cls.error),
-            surface=variables.get("surface", cls.surface),
-            border=variables.get("border", cls.border),
-            muted_text=variables.get("text-muted", cls.muted_text),
-            text=variables.get("text", cls.text),
-            # App-specific: use theme value if present, else derive from base.
-            playback_bar_bg=variables.get(
-                "playback-bar-bg", variables.get("surface", cls.playback_bar_bg)
-            ),
-            active_tab=variables.get("active-tab", variables.get("text", cls.active_tab)),
-            inactive_tab=variables.get(
-                "inactive-tab", variables.get("text-muted", cls.inactive_tab)
-            ),
-            selected_item=variables.get(
-                "selected-item", variables.get("surface", cls.selected_item)
-            ),
-            progress_filled=variables.get(
-                "progress-filled", variables.get("primary", cls.progress_filled)
-            ),
-            progress_empty=variables.get(
-                "progress-empty", variables.get("surface", cls.progress_empty)
-            ),
-            lyrics_played=variables.get(
-                "lyrics-played", variables.get("text-muted", cls.lyrics_played)
-            ),
-            lyrics_current=variables.get(
-                "lyrics-current", variables.get("success", cls.lyrics_current)
-            ),
-            lyrics_upcoming=variables.get(
-                "lyrics-upcoming", variables.get("text", cls.lyrics_upcoming)
-            ),
-        )
+def load_user_themes(themes_dir: Path = THEMES_DIR) -> list[Theme]:
+    """Load user-defined themes from the themes/ config directory.
 
-        # Apply user overrides from theme.toml (app-specific vars only).
-        tc._apply_toml_overrides()
-        return tc
+    Each TOML file must have at least ``name`` and ``primary``.  An optional
+    ``[variables]`` section maps directly to Textual CSS variables, which is
+    where ytm-player-specific colors (playback bar, lyrics, etc.) can be set.
 
-    def _apply_toml_overrides(self, path: Path = THEME_FILE) -> None:
-        """Load app-specific color overrides from theme.toml."""
-        if not path.exists():
-            return
+    Example theme file::
+
+        name = "my-theme"
+        primary = "#ff6b6b"
+        background = "#1a1a2e"
+        dark = true
+
+        [variables]
+        playback-bar-bg = "#0f3460"
+        lyrics-current = "#ff6b6b"
+    """
+    if not themes_dir.exists():
+        return []
+
+    themes: list[Theme] = []
+    for toml_file in sorted(themes_dir.glob("*.toml")):
         try:
-            with open(path, "rb") as f:
+            with open(toml_file, "rb") as f:
                 data = tomllib.load(f)
-        except (UnicodeDecodeError, tomllib.TOMLDecodeError):
-            return
+        except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError):
+            logger.warning("Could not load user theme %s — skipping", toml_file.name)
+            continue
 
-        colors = data.get("colors", data)
-        for field_name in _APP_VARS:
-            if field_name in colors:
-                setattr(self, field_name, colors[field_name])
+        if "name" not in data or "primary" not in data:
+            logger.warning(
+                "User theme %s is missing required fields 'name' and/or 'primary' — skipping",
+                toml_file.name,
+            )
+            continue
 
-    @classmethod
-    def load(cls, path: Path = THEME_FILE) -> Self:
-        """Load from theme.toml (legacy fallback for non-app contexts)."""
-        theme = cls()
-        if not path.exists():
-            return theme
         try:
-            with open(path, "rb") as f:
-                data = tomllib.load(f)
-        except (UnicodeDecodeError, tomllib.TOMLDecodeError):
-            return theme
-        colors = data.get("colors", data)
-        for f_info in fields(theme):
-            if f_info.name in colors:
-                setattr(theme, f_info.name, colors[f_info.name])
-        return theme
+            theme = Theme(
+                name=data["name"],
+                primary=data["primary"],
+                secondary=data.get("secondary"),
+                warning=data.get("warning"),
+                error=data.get("error"),
+                success=data.get("success"),
+                accent=data.get("accent"),
+                foreground=data.get("foreground"),
+                background=data.get("background"),
+                surface=data.get("surface"),
+                panel=data.get("panel"),
+                dark=data.get("dark", True),
+                variables=data.get("variables", {}),
+            )
+            themes.append(theme)
+        except Exception:
+            logger.warning(
+                "Failed to build Theme from %s — skipping", toml_file.name, exc_info=True
+            )
 
-    def save(self, path: Path = THEME_FILE) -> None:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        lines = ["[colors]"]
-        for f_info in fields(self):
-            value = getattr(self, f_info.name)
-            lines.append(f'{f_info.name} = "{value}"')
-        lines.append("")
-        path.write_text("\n".join(lines), encoding="utf-8")
+    return themes
 
 
 _theme: ThemeColors | None = None
@@ -186,7 +145,7 @@ _theme: ThemeColors | None = None
 def get_theme() -> ThemeColors:
     global _theme
     if _theme is None:
-        _theme = ThemeColors.load()
+        _theme = ThemeColors()
     return _theme
 
 

--- a/src/ytm_player/ui/widgets/progress_bar.py
+++ b/src/ytm_player/ui/widgets/progress_bar.py
@@ -58,12 +58,12 @@ class PlaybackProgress(Widget):
         classes: str | None = None,
     ) -> None:
         super().__init__(name=name, id=id, classes=classes)
-        theme = get_theme()
         self._bar_style = bar_style
-        self._filled_color = filled_color or theme.progress_filled
-        self._empty_color = empty_color or theme.progress_empty
-        self._time_color = time_color or theme.secondary
-        self._marker_color = marker_color or theme.foreground
+        # None means "follow the active theme"; a value means explicit override.
+        self._filled_color = filled_color
+        self._empty_color = empty_color
+        self._time_color = time_color
+        self._marker_color = marker_color
 
         # Scroll-seek preview state.
         self._preview_position: float | None = None
@@ -90,12 +90,18 @@ class PlaybackProgress(Widget):
         return time_prefix, time_suffix, bar_width
 
     def render(self) -> Text:
+        theme = get_theme()
+        filled_color = self._filled_color or theme.progress_filled
+        empty_color = self._empty_color or theme.progress_empty
+        time_color = self._time_color or theme.secondary
+        marker_color = self._marker_color or theme.foreground
+
         time_prefix, time_suffix, bar_width = self._bar_metrics()
         filled_count = int(bar_width * self.progress)
         empty_count = bar_width - filled_count
 
         result = Text()
-        result.append(time_prefix, style=self._time_color)
+        result.append(time_prefix, style=time_color)
 
         if self._preview_position is not None and bar_width > 0:
             # Show a marker at the preview position.
@@ -108,16 +114,16 @@ class PlaybackProgress(Widget):
 
             for i in range(bar_width):
                 if i == marker_col:
-                    result.append(self.MARKER, style=f"bold {self._marker_color}")
+                    result.append(self.MARKER, style=f"bold {marker_color}")
                 elif i < filled_count:
                     result.append(
                         self.BLOCK_FILLED if self._bar_style == "block" else self.LINE_FILLED,
-                        style=self._filled_color,
+                        style=filled_color,
                     )
                 else:
                     result.append(
                         self.BLOCK_EMPTY if self._bar_style == "block" else self.LINE_EMPTY,
-                        style=self._empty_color,
+                        style=empty_color,
                     )
         else:
             # Normal rendering (no preview).
@@ -131,10 +137,10 @@ class PlaybackProgress(Widget):
                 filled_str = self.BLOCK_FILLED * filled_count
                 empty_str = self.BLOCK_EMPTY * empty_count
 
-            result.append(filled_str, style=self._filled_color)
-            result.append(empty_str, style=self._empty_color)
+            result.append(filled_str, style=filled_color)
+            result.append(empty_str, style=empty_color)
 
-        result.append(time_suffix, style=self._time_color)
+        result.append(time_suffix, style=time_color)
         return result
 
     # ── Click to seek ─────────────────────────────────────────────


### PR DESCRIPTION
Closes #35
Fixes #39

## Summary

- Adds `THEMES_DIR` (`~/.config/ytm-player/themes/` on Linux/macOS, `%APPDATA%\ytm-player\themes\` on Windows) — created automatically on first launch
- `load_user_themes()` reads `*.toml` files from `themes/`, builds Textual `Theme` objects and skips invalid files with a warning. Only `name` and `primary` are required; a `[variables]` section maps to Textual CSS variables for ytm-player-specific colors (progress bar, lyrics, playback bar bg)
- `_register_themes()` in `YTMPlayerApp` registers `ytm-dark` and all user themes at startup — they appear in the Ctrl+P picker alongside the 18 built-in Textual themes
- Removes the legacy `theme.toml` system entirely (`_apply_toml_overrides`, `ThemeColors.load/save`, `THEME_FILE`) — app-specific colors are now derived from the active theme's palette or set via `[variables]`
- Fixes `PlaybackProgress` caching colors at construction time — colors are now read from `get_theme()` in `render()` so they update immediately on theme switch
- README updated: `theme.toml` references replaced with `themes/` directory docs and custom theme format example

## Test plan

- [x] Minimal theme (`name` + `primary` only) — appears in Ctrl+P and applies correctly, palette derived automatically
- [x] Full theme with all colors and `[variables]` — all colors apply as expected
- [x] Invalid TOML or missing required fields — app starts normally, skips broken file with a warning
- [x] Built-in Textual themes (catppuccin-mocha, dracula, etc.) — app-specific colors derived from palette correctly
- [x] Progress bar color updates immediately when switching themes
- [x] Empty `themes/` directory — no errors, built-in themes unaffected
- [x] `themes/` directory does not exist — no errors, created automatically on first launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)