### PR TITLE
Theme colors don't update in header bar when switching themes

### DIFF
--- a/src/ytm_player/ui/header_bar.py
+++ b/src/ytm_player/ui/header_bar.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from rich.text import Text
 from textual.app import ComposeResult
 from textual.containers import Horizontal
 from textual.events import Click
@@ -10,8 +9,6 @@ from textual.message import Message
 from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Static
-
-from ytm_player.ui.theme import get_theme
 
 
 class HeaderBar(Widget):
@@ -41,9 +38,18 @@ class HeaderBar(Widget):
         height: 1;
         width: auto;
         padding: 0 1;
+        color: $text-muted;
     }
     HeaderBar .hb-toggle:hover {
         background: $border;
+    }
+    HeaderBar .hb-toggle.active {
+        color: $primary;
+        text-style: bold;
+    }
+    HeaderBar .hb-toggle.dimmed {
+        color: $text-muted;
+        text-style: dim;
     }
     """
 
@@ -53,13 +59,9 @@ class HeaderBar(Widget):
 
     def compose(self) -> ComposeResult:
         with Horizontal(id="header-inner"):
-            yield Static(id="toggle-playlist", classes="hb-toggle")
+            yield Static("\u2630 Playlists", id="toggle-playlist", classes="hb-toggle")
             yield Static(id="header-spacer")
-            yield Static(id="toggle-lyrics", classes="hb-toggle")
-
-    def on_mount(self) -> None:
-        self._update_playlist_label()
-        self._update_lyrics_label()
+            yield Static("\u266b Lyrics", id="toggle-lyrics", classes="hb-toggle")
 
     def on_click(self, event: Click) -> None:
         """Route clicks on toggle buttons to the correct message."""
@@ -75,38 +77,29 @@ class HeaderBar(Widget):
 
     def set_playlist_state(self, is_open: bool) -> None:
         self.is_playlist_on = is_open
-        self._update_playlist_label()
-
-    def set_lyrics_state(self, is_open: bool) -> None:
-        self.is_lyrics_on = is_open
-        self._update_lyrics_label()
-
-    def set_lyrics_dimmed(self, dimmed: bool) -> None:
-        self.is_lyrics_dimmed = dimmed
-        self._update_lyrics_label()
-
-    def _update_playlist_label(self) -> None:
         try:
-            theme = get_theme()
-            btn = self.query_one("#toggle-playlist", Static)
-            label = "\u2630 Playlists"
-            if self.is_playlist_on:
-                btn.update(Text(label, style=f"bold {theme.primary}"))
-            else:
-                btn.update(Text(label, style=theme.muted_text))
+            self.query_one("#toggle-playlist", Static).set_class(is_open, "active")
         except Exception:
             pass
 
-    def _update_lyrics_label(self) -> None:
+    def set_lyrics_state(self, is_open: bool) -> None:
+        self.is_lyrics_on = is_open
+        self._apply_lyrics_classes()
+
+    def set_lyrics_dimmed(self, dimmed: bool) -> None:
+        self.is_lyrics_dimmed = dimmed
+        self._apply_lyrics_classes()
+
+    def _apply_lyrics_classes(self) -> None:
         try:
-            theme = get_theme()
             btn = self.query_one("#toggle-lyrics", Static)
-            label = "\u266b Lyrics"
             if self.is_lyrics_dimmed:
-                btn.update(Text(label, style="dim"))
+                btn.remove_class("active")
+                btn.add_class("dimmed")
             elif self.is_lyrics_on:
-                btn.update(Text(label, style=f"bold {theme.primary}"))
+                btn.remove_class("dimmed")
+                btn.add_class("active")
             else:
-                btn.update(Text(label, style=theme.muted_text))
+                btn.remove_class("active", "dimmed")
         except Exception:
             pass


### PR DESCRIPTION
Closes #37

## Summary

- Migrates `HeaderBar` toggle labels from Rich Text + `get_theme()` to pure CSS classes (`active`, `dimmed`) using `$primary` and `$text-muted` CSS variables.
- Removes `on_mount`, `_update_playlist_label`, `_update_lyrics_label` and the `get_theme` / `rich.text.Text` imports.
- Colors now resolve at render time, so Textual's `refresh_css` on theme change is sufficient — no manual repaint needed.

## Test plan

- [x] Switch themes and verify "☰ Playlists" and "♫ Lyrics" buttons update colors immediately, without needing to click a nav item.
- [x] Toggle playlist/lyrics sidebars and verify active/inactive states still render correctly with the correct colors.
- [x] Verify dimmed state (lyrics button before any track plays) still renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)