### PR TITLE
fix: optimistic create/delete for playlist sidebar

### DIFF
--- a/src/ytm_player/app/_sidebar.py
+++ b/src/ytm_player/app/_sidebar.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 
 from ytm_player.ui.header_bar import HeaderBar
@@ -215,7 +214,8 @@ class SidebarMixin:
             if playlist_id:
                 self.notify(f"Created '{name}'", timeout=2)
                 ps = self.query_one("#playlist-sidebar", PlaylistSidebar)
-                await ps.refresh_playlists()
+                panel = ps.query_one("#ps-playlists")
+                panel.prepend_item({"playlistId": playlist_id, "title": name})
             else:
                 self.notify("Failed to create playlist", severity="error", timeout=3)
         except Exception:
@@ -243,9 +243,8 @@ class SidebarMixin:
                 success = await self.ytmusic.remove_album_from_library(raw_id)
             if success:
                 self.notify(f"Removed '{title}'", timeout=2)
-                await asyncio.sleep(1)
                 ps = self.query_one("#playlist-sidebar", PlaylistSidebar)
-                await ps.refresh_playlists()
+                ps.query_one("#ps-playlists").remove_item(raw_id)
             else:
                 self.notify("Failed to remove playlist", severity="error", timeout=3)
         except Exception:

--- a/src/ytm_player/ui/sidebars/playlist_sidebar.py
+++ b/src/ytm_player/ui/sidebars/playlist_sidebar.py
@@ -151,6 +151,31 @@ class LibraryPanel(Widget):
         self._set_loading_visible(False)
         self.is_loading = False
 
+    def prepend_item(self, item: dict[str, Any]) -> None:
+        """Optimistically insert *item* at the top of the panel."""
+        self._items.insert(0, item)
+        self._filtered_items.insert(0, item)
+        list_view = self.query_one(ListView)
+        list_view.insert(0, [ListItem(Label(self._format_item(item)))])
+        count_label = self.query_one(".panel-count", Static)
+        total = len(self._items)
+        shown = len(self._filtered_items)
+        if shown == total:
+            count_label.update(f"{total} item{'s' if total != 1 else ''}")
+        else:
+            count_label.update(f"{shown}/{total}")
+
+    def remove_item(self, playlist_id: str) -> None:
+        """Optimistically remove the item with *playlist_id* from the panel."""
+
+        def matches(item: dict[str, Any]) -> bool:
+            pid = item.get("playlistId") or item.get("browseId", "")
+            return pid == playlist_id or pid == f"VL{playlist_id}"
+
+        self._items = [i for i in self._items if not matches(i)]
+        self._filtered_items = [i for i in self._filtered_items if not matches(i)]
+        self._rebuild_list(self._filtered_items)
+
     def _rebuild_list(self, items: list[dict[str, Any]]) -> None:
         list_view = self.query_one(ListView)
         list_view.clear()


### PR DESCRIPTION
Closes #40

## Summary

- On **create**: immediately prepends the new playlist to the sidebar using the `playlist_id` and `name` already returned by the API — no extra round-trip needed.
- On **delete**: immediately removes the item by `playlist_id` and drops the `asyncio.sleep(1)` that was there to wait for the API to catch up.
- Adds `prepend_item()` and `remove_item()` to `LibraryPanel` for the optimistic updates.

The API already confirms success before the UI change, so the optimistic update is safe.

## Test plan

- [x] Create a playlist — appears immediately at the top of the sidebar without delay
- [x] Delete a playlist — disappears immediately from the sidebar without delay
- [x] API failure on create/delete — error notification shown, sidebar unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)