### PR TITLE
fix(macos): handles built-in keyboard media key codes for next/prev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ A reliability and quality release driven by a multi-agent expert audit. Hardens 
 - **README polish** — badges, tagline, Contributors section.
 - **Audit-driven follow-up plans** at `docs/superpowers/plans/2026-04-28-audit-driven-error-handling-cleanup.md` and `docs/superpowers/plans/2026-04-28-audit-driven-followup.md` — written via the superpowers writing-plans + subagent-driven-development workflow.
 
+### Unreleased
+
+**Fixes**
+
+- macOS built-in keyboard media keys (prev/next) now work — built-in MacBook keyboards send key codes 19/20 (fast-forward/rewind) instead of the standard 17/18 (next/previous) that external keyboards use. The Quartz event tap now maps both sets.
+
 ---
 
 ### v1.7.2 (2026-04-27)

--- a/src/ytm_player/services/macos_eventtap.py
+++ b/src/ytm_player/services/macos_eventtap.py
@@ -33,11 +33,15 @@ _MEDIA_KEY_DOWN_STATE = 0xA
 _PLAY_PAUSE_KEY = 16
 _NEXT_KEY = 17
 _PREVIOUS_KEY = 18
+_FAST_FORWARD_KEY = 19
+_REWIND_KEY = 20
 
 _KEY_TO_ACTION = {
     _PLAY_PAUSE_KEY: "play_pause",
     _NEXT_KEY: "next",
     _PREVIOUS_KEY: "previous",
+    _FAST_FORWARD_KEY: "next",
+    _REWIND_KEY: "previous",
 }
 
 


### PR DESCRIPTION
## Summary
- MacBook built-in keyboards send key codes 19/20 (fast-forward/rewind) instead of 17/18 (next/previous) for media keys; maps both sets in the Quartz event tap
- Reverts unnecessary input_media_keys=False on mpv since the root cause was unmapped key codes, not mpv stealing media key registration