### PR TITLE
fix(ui): browse tab bar visibility and contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ A reliability and quality release driven by a multi-agent expert audit. Hardens 
 - **README polish** — badges, tagline, Contributors section.
 - **Audit-driven follow-up plans** at `docs/superpowers/plans/2026-04-28-audit-driven-error-handling-cleanup.md` and `docs/superpowers/plans/2026-04-28-audit-driven-followup.md` — written via the superpowers writing-plans + subagent-driven-development workflow.
 
+### Unreleased
+
+**Fixes**
+
+- Browse tab bar now renders correctly — `.tab-item` height increased from 1 to 3 rows so text is visible, tabs sized with `width: auto` so all four render side-by-side, hover state added for discoverability, and tab bar background set to `$surface` for contrast.
+
 ---
 
 ### v1.7.2 (2026-04-27)

--- a/src/ytm_player/ui/pages/browse.py
+++ b/src/ytm_player/ui/pages/browse.py
@@ -38,6 +38,8 @@ class BrowseTabBar(Widget):
         height: 3;
         width: 1fr;
         padding: 0 1;
+        background: $surface;
+        border-bottom: solid $border;
     }
 
     BrowseTabBar Horizontal {
@@ -46,16 +48,23 @@ class BrowseTabBar(Widget):
     }
 
     BrowseTabBar .tab-item {
+        width: auto;
+        min-width: 12;
         padding: 0 2;
-        height: 1;
+        height: 3;
         content-align: center middle;
         color: $text-muted;
+        border-bottom: tall transparent;
+    }
+
+    BrowseTabBar .tab-item:hover {
+        color: $text;
     }
 
     BrowseTabBar .tab-item.active {
         text-style: bold;
         color: $text;
-        border-bottom: solid $primary;
+        border-bottom: tall $primary;
     }
     """
 


### PR DESCRIPTION
## Summary
- Tab bar was rendering at height 1, making all four tabs (For You, Moods & Genres, Charts, New Releases) invisible; increased to height 3 with `width: auto` sizing, hover state, and `$surface` background for contrast
- While testing, discovered that 3 of 4 tab contents appear broken on the current codebase: Moods & Genres fails to load, Charts shows `Country: ZZ` with no data, and New Releases loads but displays nothing. These are pre-existing issues (no logic changes in this PR). Want us to investigate/fix those as a follow-up?