### PR TITLE
feat(browse): configurable home shelf count via [ui] home_shelves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ A reliability and quality release driven by a multi-agent expert audit. Hardens 
 - **README polish** — badges, tagline, Contributors section.
 - **Audit-driven follow-up plans** at `docs/superpowers/plans/2026-04-28-audit-driven-error-handling-cleanup.md` and `docs/superpowers/plans/2026-04-28-audit-driven-followup.md` — written via the superpowers writing-plans + subagent-driven-development workflow.
 
+### Unreleased
+
+**New**
+
+- Configurable home shelf count — set `home_shelves` under `[ui]` in `config.toml` to control how many recommendation shelves are fetched on the Browse > For You tab (default: 3, range: 1–25).
+- For You shelves scroll as a single section instead of each shelf scrolling independently, with subtle separators and colored section titles for readability.
+
 ---
 
 ### v1.7.2 (2026-04-27)

--- a/src/ytm_player/config/settings.py
+++ b/src/ytm_player/config/settings.py
@@ -78,6 +78,7 @@ class UISettings:
     col_album: int = 0
     col_duration: int = 8
     bidi_mode: str = "auto"  # "auto", "reorder", "passthrough"
+    home_shelves: int = 3
 
 
 @dataclass
@@ -184,6 +185,8 @@ class Settings:
                 for f_info in fields(section_instance):
                     if f_info.name in section_data:
                         setattr(section_instance, f_info.name, section_data[f_info.name])
+
+        settings.ui.home_shelves = max(1, min(25, settings.ui.home_shelves))
 
         return settings
 

--- a/src/ytm_player/services/ytmusic.py
+++ b/src/ytm_player/services/ytmusic.py
@@ -271,10 +271,10 @@ class YTMusicService:
     # Browsing
     # ------------------------------------------------------------------
 
-    async def get_home(self) -> list[dict[str, Any]]:
+    async def get_home(self, limit: int = 3) -> list[dict[str, Any]]:
         """Return personalised home page recommendations."""
         try:
-            return await self._call(self.client.get_home, limit=3)
+            return await self._call(self.client.get_home, limit=limit)
         except Exception:
             logger.exception("get_home failed")
             return []

--- a/src/ytm_player/ui/pages/browse.py
+++ b/src/ytm_player/ui/pages/browse.py
@@ -6,7 +6,7 @@ import logging
 from typing import TYPE_CHECKING, Any, cast
 
 from textual.app import ComposeResult
-from textual.containers import Horizontal, Vertical
+from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.events import Click
 from textual.message import Message
 from textual.reactive import reactive
@@ -14,6 +14,7 @@ from textual.widget import Widget
 from textual.widgets import Label, ListItem, ListView, Static
 
 from ytm_player.config.keymap import Action
+from ytm_player.config.settings import get_settings
 from ytm_player.ui.widgets.track_table import TrackTable
 from ytm_player.utils.formatting import extract_artist, get_video_id, normalize_tracks, truncate
 
@@ -120,13 +121,15 @@ class ForYouSection(Widget):
 
     ForYouSection .shelf-title {
         text-style: bold;
-        color: $text;
+        color: $primary;
         padding: 1 0 0 0;
     }
 
     ForYouSection .shelf-items {
         height: auto;
-        max-height: 6;
+        padding: 0 0 1 0;
+        margin: 0 0 1 0;
+        border-bottom: solid $border;
     }
 
     ForYouSection .loading {
@@ -150,7 +153,7 @@ class ForYouSection(Widget):
 
     def compose(self) -> ComposeResult:
         yield Static("Loading recommendations...", id="foryou-loading", classes="loading")
-        yield Vertical(id="foryou-shelves")
+        yield VerticalScroll(id="foryou-shelves")
 
     def on_unmount(self) -> None:
         """Release shelf data to prevent memory retention."""
@@ -162,7 +165,8 @@ class ForYouSection(Widget):
         try:
             ytmusic = cast("YTMHostBase", self.app).ytmusic
             assert ytmusic is not None
-            self._shelves = await ytmusic.get_home()
+            limit = get_settings().ui.home_shelves
+            self._shelves = await ytmusic.get_home(limit=limit)
         except Exception:
             logger.debug("Failed to load home recommendations", exc_info=True)
             self._show_error("Failed to load recommendations.")
@@ -175,7 +179,7 @@ class ForYouSection(Widget):
             logger.debug("Failed to render home shelves", exc_info=True)
             # Clean up any partially-mounted widgets.
             try:
-                container = self.query_one("#foryou-shelves", Vertical)
+                container = self.query_one("#foryou-shelves", VerticalScroll)
                 await container.remove_children()
             except Exception:
                 pass
@@ -187,7 +191,7 @@ class ForYouSection(Widget):
         loading = self.query_one("#foryou-loading", Static)
         loading.display = False
 
-        container = self.query_one("#foryou-shelves", Vertical)
+        container = self.query_one("#foryou-shelves", VerticalScroll)
         # Clear _shelf_items references from old ListViews before removing.
         for lv in container.query(ListView):
             if hasattr(lv, "_shelf_items"):


### PR DESCRIPTION
## Summary
- Adds `home_shelves` setting under `[ui]` in config.toml (default: 3, range: 1-25) to control how many recommendation shelves are fetched on the Browse > For You tab
- For You shelves now scroll as a single section instead of each shelf scrolling independently, with colored section titles and subtle separators between shelves