### PR TITLE
feat(radio): start radio from playlist context menu and header button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ A reliability and quality release driven by a multi-agent expert audit. Hardens 
 - **README polish** — badges, tagline, Contributors section.
 - **Audit-driven follow-up plans** at `docs/superpowers/plans/2026-04-28-audit-driven-error-handling-cleanup.md` and `docs/superpowers/plans/2026-04-28-audit-driven-followup.md` — written via the superpowers writing-plans + subagent-driven-development workflow.
 
+### Unreleased
+
+**New**
+
+- Playlist radio — right-click any sidebar playlist and choose "Start Radio", or click the "[▶ Start Radio]" button in the playlist header (Library and Context pages). Seeds a radio queue via `RDAMPL` + playlist ID.
+- "Add to Library" button now only shows for playlists you don't own. Both header buttons were previously invisible due to a layout bug (Label taking full width); fixed with `width: auto`.
+
 ---
 
 ### v1.7.2 (2026-04-27)

--- a/src/ytm_player/app/_sidebar.py
+++ b/src/ytm_player/app/_sidebar.py
@@ -209,6 +209,12 @@ class SidebarMixin(YTMHostBase):
                     self.run_worker(self._add_playlist_to_queue(pid))
                 else:
                     self.notify("No playlist ID found", severity="error", timeout=2)
+            elif action_id == "start_radio":
+                pid = item.get("playlistId") or item.get("browseId")
+                if pid:
+                    self.run_worker(self._start_playlist_radio(item))
+                else:
+                    self.notify("No playlist ID found", severity="error", timeout=2)
             elif action_id == "delete":
                 from ytm_player.ui.popups.confirm_popup import ConfirmPopup
 
@@ -259,6 +265,31 @@ class SidebarMixin(YTMHostBase):
         except Exception:
             logger.exception("Failed to create playlist %r", name)
             self.notify("Failed to create playlist", severity="error", timeout=3)
+
+    async def _start_playlist_radio(self, item: dict) -> None:
+        """Start radio seeded from a sidebar playlist."""
+        from ytm_player.utils.formatting import normalize_tracks
+
+        playlist_id = item.get("playlistId") or item.get("browseId")
+        if not playlist_id or not self.ytmusic:
+            return
+
+        self.notify("Starting radio...", timeout=3)
+        try:
+            radio_tracks = normalize_tracks(await self.ytmusic.get_playlist_radio(playlist_id))
+        except Exception:
+            logger.exception("Failed to start playlist radio for %r", playlist_id)
+            self.notify("Failed to start radio", severity="error")
+            return
+
+        if radio_tracks:
+            self.queue.clear()
+            self.queue.set_radio_tracks(radio_tracks)
+            first = self.queue.next_track()
+            if first:
+                await self.play_track(first)
+        else:
+            self.notify("No radio tracks found", severity="warning", timeout=3)
 
     async def _delete_sidebar_playlist(self, item: dict) -> None:
         """Delete or remove a playlist and refresh the sidebar."""

--- a/src/ytm_player/services/ytmusic.py
+++ b/src/ytm_player/services/ytmusic.py
@@ -482,6 +482,23 @@ class YTMusicService:
             logger.exception("get_radio failed for %r", video_id)
             return []
 
+    async def get_playlist_radio(self, playlist_id: str) -> list[dict]:
+        """Start a radio from a playlist via RDAMPL prefix."""
+        stripped = playlist_id.removeprefix("VL")
+        try:
+            result = await self._call(
+                self.client.get_watch_playlist,
+                playlistId="RDAMPL" + stripped,
+                radio=True,
+            )
+        except Exception:
+            logger.exception("Playlist radio failed for %s", playlist_id)
+            return []
+        tracks = result.get("tracks", []) if isinstance(result, dict) else []
+        if not tracks:
+            logger.warning("Playlist radio returned no tracks for %s", playlist_id)
+        return tracks
+
     # ------------------------------------------------------------------
     # Library actions
     # ------------------------------------------------------------------

--- a/src/ytm_player/ui/pages/context.py
+++ b/src/ytm_player/ui/pages/context.py
@@ -103,9 +103,23 @@ class ContextPage(Widget):
     #add-to-library-btn:hover {
         background: $primary 30%;
     }
+    #start-radio-btn {
+        width: auto;
+        min-width: 14;
+        height: 1;
+        margin: 0 0 0 1;
+        padding: 0 1;
+        color: $primary;
+    }
+    #start-radio-btn:hover {
+        background: $primary 30%;
+    }
     .context-header-row {
         height: auto;
         width: 1fr;
+    }
+    .context-header-row Label {
+        width: auto;
     }
     .context-body {
         height: 1fr;
@@ -349,8 +363,11 @@ class ContextPage(Widget):
         container.mount(header)
         title_row = Horizontal(classes="context-header-row")
         header.mount(title_row)
+        owned = data.get("owned", False)
         title_row.mount(Label("[b]Playlist[/b]", markup=True))
-        title_row.mount(Static("[+ Add to Library]", id="add-to-library-btn", markup=True))
+        if not owned:
+            title_row.mount(Static("[+ Add to Library]", id="add-to-library-btn", markup=True))
+        title_row.mount(Static("[▶ Start Radio]", id="start-radio-btn", markup=True))
         header.mount(Label(title, classes="context-title"))
         header.mount(Label(subtitle, classes="context-subtitle"))
         unavailable = len(raw_tracks) - track_count
@@ -504,13 +521,16 @@ class ContextPage(Widget):
     # ── Events ────────────────────────────────────────────────────────
 
     def on_click(self, event: Click) -> None:
-        """Handle clicks on the add-to-library button."""
+        """Handle clicks on header action buttons."""
         widget = event.widget
         if widget is None:
             return
         if widget.id == "add-to-library-btn":
             event.stop()
             self.run_worker(self._add_to_library(), name="add_to_lib", exclusive=True)
+        elif widget.id == "start-radio-btn":
+            event.stop()
+            self.run_worker(self._start_radio(), name="start_radio", exclusive=True)
 
     async def _add_to_library(self) -> None:
         """Add the current album or playlist to the user's library."""
@@ -549,6 +569,12 @@ class ContextPage(Widget):
         else:
             suffix = mutation_failure_suffix(result)
             self.app.notify(f"Failed to add to library — {suffix}", severity="error", timeout=4)
+
+    async def _start_radio(self) -> None:
+        """Start radio seeded from the current playlist."""
+        data = self._data
+        data.setdefault("playlistId", self.context_id)
+        await self.app._start_playlist_radio(data)  # type: ignore[attr-defined]
 
     async def on_track_table_track_selected(self, event: TrackTable.TrackSelected) -> None:
         """Play the selected track and enqueue remaining tracks."""

--- a/src/ytm_player/ui/pages/library.py
+++ b/src/ytm_player/ui/pages/library.py
@@ -6,7 +6,8 @@ import logging
 from typing import TYPE_CHECKING, Any, cast
 
 from textual.app import ComposeResult
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
+from textual.events import Click
 from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Input, Label, Static
@@ -41,12 +42,29 @@ class LibraryPage(Widget):
         padding: 1 2;
     }
 
+    .content-title-row {
+        height: auto;
+        width: 1fr;
+    }
+    .content-title-row Label {
+        width: auto;
+    }
     .content-title {
         text-style: bold;
     }
-
     .content-subtitle {
         color: $text-muted;
+    }
+    #start-radio-btn {
+        width: auto;
+        min-width: 14;
+        height: 1;
+        margin: 0 0 0 1;
+        padding: 0 1;
+        color: $primary;
+    }
+    #start-radio-btn:hover {
+        background: $primary 30%;
     }
 
     #empty-state {
@@ -177,11 +195,19 @@ class LibraryPage(Widget):
             track_count = len(tracks)
             total_count = data.get("trackCount") or track_count
 
+            # Store data for radio button — ensure playlistId is set since
+            # get_playlist() returns 'id' but _start_playlist_radio expects 'playlistId'.
+            self._playlist_data = data
+            self._playlist_data.setdefault("playlistId", playlist_id)
+
             # Update header.
             header = self.query_one("#content-header", Vertical)
             await header.remove_children()
             header.display = True
-            await header.mount(Label(title, classes="content-title"))
+            title_row = Horizontal(classes="content-title-row")
+            await header.mount(title_row)
+            await title_row.mount(Label(title, classes="content-title"))
+            await title_row.mount(Static("[▶ Start Radio]", id="start-radio-btn", markup=True))
             subtitle = f"{owner} \u00b7 {track_count} track{'s' if track_count != 1 else ''}"
             if total_count > track_count:
                 subtitle += f" (loading {total_count} total\u2026)"
@@ -316,6 +342,22 @@ class LibraryPage(Widget):
                     self.query_one("#library-tracks", TrackTable).clear_filter()
             except Exception:
                 pass
+
+    # ------------------------------------------------------------------
+    # Header button clicks
+    # ------------------------------------------------------------------
+
+    def on_click(self, event: Click) -> None:
+        """Handle clicks on header action buttons."""
+        if event.widget.id == "start-radio-btn":
+            event.stop()
+            data = getattr(self, "_playlist_data", None)
+            if data:
+                self.run_worker(
+                    self.app._start_playlist_radio(data),  # type: ignore[attr-defined]
+                    name="start_radio",
+                    exclusive=True,
+                )
 
     # ------------------------------------------------------------------
     # Track selection → play

--- a/src/ytm_player/ui/popups/actions.py
+++ b/src/ytm_player/ui/popups/actions.py
@@ -50,6 +50,7 @@ PLAYLIST_ACTIONS: list[tuple[str, str]] = [
     ("play_all", "Play All"),
     ("shuffle_play", "Shuffle Play"),
     ("add_to_queue", "Add to Queue"),
+    ("start_radio", "Start Radio"),
     ("copy_link", "Copy Link"),
     ("delete", "Delete Playlist"),
 ]

--- a/tests/test_services/test_playlist_radio.py
+++ b/tests/test_services/test_playlist_radio.py
@@ -1,0 +1,103 @@
+"""Tests for YTMusicService.get_playlist_radio()."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ytm_player.services.ytmusic import YTMusicService
+
+
+def _make_raw_track(video_id: str = "abc123", title: str = "Song") -> dict:
+    return {
+        "videoId": video_id,
+        "title": title,
+        "artists": [{"name": "Artist", "id": "UCxxx"}],
+        "album": {"name": "Album", "id": "MPREb_xxx"},
+        "duration_seconds": 180,
+        "thumbnails": [{"url": "https://example.com/thumb.jpg"}],
+        "isAvailable": True,
+    }
+
+
+@pytest.fixture
+def service() -> YTMusicService:
+    svc = YTMusicService.__new__(YTMusicService)
+    svc._ytm = MagicMock()
+    svc._consecutive_api_failures = 0
+    svc._order_lock = None
+    return svc
+
+
+async def test_get_playlist_radio_strips_vl_prefix(service: YTMusicService) -> None:
+    """VL-prefixed playlist IDs should be stripped before forming the RDAMPL key."""
+    raw_tracks = [_make_raw_track()]
+    result_dict = {"tracks": raw_tracks}
+
+    with patch.object(service, "_call", new=AsyncMock(return_value=result_dict)) as mock_call:
+        tracks = await service.get_playlist_radio("VLPLabc123")
+
+    mock_call.assert_called_once_with(
+        service.client.get_watch_playlist,
+        playlistId="RDAMPLPLabc123",
+        radio=True,
+    )
+    assert tracks == raw_tracks
+
+
+async def test_get_playlist_radio_no_vl_prefix(service: YTMusicService) -> None:
+    """Playlist IDs without VL prefix should be used as-is."""
+    raw_tracks = [_make_raw_track("vid1"), _make_raw_track("vid2")]
+    result_dict = {"tracks": raw_tracks}
+
+    with patch.object(service, "_call", new=AsyncMock(return_value=result_dict)) as mock_call:
+        tracks = await service.get_playlist_radio("PLabc123")
+
+    mock_call.assert_called_once_with(
+        service.client.get_watch_playlist,
+        playlistId="RDAMPLPLabc123",
+        radio=True,
+    )
+    assert tracks == raw_tracks
+
+
+async def test_get_playlist_radio_returns_tracks(service: YTMusicService) -> None:
+    """Returns the tracks list from the API response."""
+    raw_tracks = [_make_raw_track("v1"), _make_raw_track("v2"), _make_raw_track("v3")]
+
+    with patch.object(service, "_call", new=AsyncMock(return_value={"tracks": raw_tracks})):
+        tracks = await service.get_playlist_radio("PLtest")
+
+    assert tracks == raw_tracks
+    assert len(tracks) == 3
+
+
+async def test_get_playlist_radio_empty_response_logs_warning(
+    service: YTMusicService, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An empty track list from the API should emit a warning log."""
+    with patch.object(service, "_call", new=AsyncMock(return_value={"tracks": []})):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="ytm_player.services.ytmusic"):
+            tracks = await service.get_playlist_radio("PLempty")
+
+    assert tracks == []
+    assert any("no tracks" in record.message.lower() for record in caplog.records)
+
+
+async def test_get_playlist_radio_exception_returns_empty(service: YTMusicService) -> None:
+    """On API failure, returns empty list without raising."""
+    with patch.object(service, "_call", new=AsyncMock(side_effect=Exception("network error"))):
+        tracks = await service.get_playlist_radio("PLfail")
+
+    assert tracks == []
+
+
+async def test_get_playlist_radio_non_dict_response_returns_empty(service: YTMusicService) -> None:
+    """If the API returns a non-dict, returns empty list."""
+    with patch.object(service, "_call", new=AsyncMock(return_value=None)):
+        tracks = await service.get_playlist_radio("PLnone")
+
+    assert tracks == []


### PR DESCRIPTION
## Summary
- Adds "Start Radio" to the playlist sidebar context menu, seeding a radio queue via `RDAMPL` + playlist ID
- Adds a clickable "Start Radio" button to the playlist header on both the Library page and Context page, making radio discoverable without hunting through context menus
- "Add to Library" button now conditionally hidden for owned playlists; also fixes a pre-existing layout bug where both header buttons were invisible (Label width defaulting to 1fr pushed them off-screen)