### PR TITLE
feat(radio): proactive queue refill, discovery mix, multi-seed radio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+### Unreleased
+
+**New**
+
+- **Proactive queue refill** — autoplay silently tops up the queue before it runs dry, seeded from recently-played tracks
+- **Discovery Mix** — new sidebar item that plays a random mix from your home picks, trending, moods, charts, liked songs, library artists, or listening history
+- **Multi-seed radio** — radio requests use multiple seeds for better variety
+
+---
+
 ### v1.8.0 (2026-04-28)
 
 A reliability and quality release driven by a multi-agent expert audit. Hardens error handling across the service/UI cascade so silent-failure UX is replaced with actionable feedback, fixes several latent runtime bugs, and brings the codebase to zero non-exempted Pyright errors (down from 218).

--- a/src/ytm_player/app/_playback.py
+++ b/src/ytm_player/app/_playback.py
@@ -247,7 +247,12 @@ class PlaybackMixin(YTMHostBase):
             # is already None (cleared by _on_end_file before we get here).
             seed = ended_track or (self.player.current_track if self.player else None)
             if seed:
-                await self._fetch_and_play_radio(seed_track=seed)
+                await self._fetch_and_play_radio(seed_track=seed, append=True)
+                first = self.queue.next_track()
+                if first:
+                    await self.play_track(first)
+                else:
+                    self.notify("End of queue.", timeout=2)
             else:
                 self.notify("End of queue.", timeout=2)
         else:
@@ -264,38 +269,54 @@ class PlaybackMixin(YTMHostBase):
         if track:
             await self.play_track(track)
 
-    async def _fetch_and_play_radio(self, seed_track: dict | None = None) -> None:
-        """Fetch radio suggestions and continue playback.
+    async def _fetch_and_play_radio(
+        self,
+        seed_track: dict | list[dict],
+        *,
+        label: str | None = None,
+        append: bool = False,
+    ) -> None:
+        """Fetch radio for one or more seed tracks and load into queue.
 
-        *seed_track* is used as the radio seed.  Falls back to the player's
-        current track if not provided.
+        When *append* is False (default), clears the queue first and starts
+        playback — used for user-initiated "Start Radio" / discovery mix.
+        When *append* is True, silently adds tracks — used for background
+        queue refill.
         """
         if not self.ytmusic:
             return
-
-        track = seed_track or (self.player.current_track if self.player else None)
-        if not track:
+        seeds = [seed_track] if isinstance(seed_track, dict) else seed_track
+        video_ids = [get_video_id(t) for t in seeds if get_video_id(t)]
+        if not video_ids:
             return
 
-        video_id = track.get("video_id", "")
-        if not video_id:
-            return
+        if not append:
+            self.notify("Loading radio...", timeout=3)
 
-        self.notify("Loading radio suggestions...", timeout=3)
         try:
-            from ytm_player.utils.formatting import normalize_tracks
-
-            radio_tracks = normalize_tracks(await self.ytmusic.get_radio(video_id))
-            if radio_tracks:
-                self.queue.set_radio_tracks(radio_tracks)
-                next_track = self.queue.next_track()
-                if next_track:
-                    await self.play_track(next_track)
-                    return
+            tracks = await self.ytmusic.get_radio(video_ids)
         except Exception:
-            logger.exception("Failed to fetch radio tracks")
+            logger.exception("Failed to fetch radio")
+            tracks = []
 
-        self.notify("No more suggestions available. Add more tracks to your queue.", timeout=3)
+        if not tracks:
+            if not append:
+                self.notify("No radio suggestions available.", severity="warning", timeout=3)
+            return
+
+        if append:
+            self.queue.set_radio_tracks(tracks)
+            self._refresh_queue_page()
+            return
+
+        self.queue.clear()
+        self.queue.set_radio_tracks(tracks)
+        self._refresh_queue_page()
+        label = label or f"Radio generated from {seeds[0].get('title', 'Unknown')}"
+        first = self.queue.next_track()
+        if first:
+            await self.play_track(first)
+        self.notify(f"Playing: {label}", timeout=4)
 
     # ── Player event callbacks ───────────────────────────────────────
 
@@ -366,6 +387,8 @@ class PlaybackMixin(YTMHostBase):
 
         Called on the event loop via call_soon_threadsafe -- safe to touch widgets.
         """
+        self._refill_queue()
+
         try:
             bar = self.query_one("#playback-bar", PlaybackBar)
             bar.update_track(track)
@@ -434,6 +457,47 @@ class PlaybackMixin(YTMHostBase):
                     group="prefetch",
                     exclusive=True,
                 )
+
+    def _refill_queue(self) -> None:
+        """Refill the queue in the background when tracks are running low."""
+        if self.queue.repeat_mode != "off":
+            return
+        if not self.settings.playback.autoplay:
+            return
+        if self.queue.remaining_tracks > 3:
+            return
+        for worker in self.workers:
+            if worker.group == "queue_extend" and worker.is_running:
+                return
+
+        all_tracks = self.queue.tracks
+        current_idx = self.queue.real_index
+        played = list(all_tracks[: current_idx + 1]) if current_idx >= 0 else []
+        seeds = played[-5:]
+        if not seeds:
+            track = self.player.current_track if self.player else None
+            if track:
+                seeds = [track]
+        if not seeds:
+            return
+
+        self.run_worker(
+            self._fetch_and_play_radio(seeds, append=True),
+            group="queue_extend",
+            exclusive=True,
+        )
+
+    async def _start_discovery_mix(self) -> None:
+        """Fetch a random discovery mix, replace the queue, and start playing."""
+        if not self.ytmusic:
+            return
+        self.notify("Loading discovery mix...", timeout=3)
+        seeds, label = await self.ytmusic.get_discovery_mix()
+        if not seeds:
+            self.notify("Discovery failed — no content available", severity="warning")
+            return
+        await self._fetch_and_play_radio(seeds, label=label)
+        await self.navigate_to("queue")
 
     def _on_volume_change(self, volume: int) -> None:
         """Handle volume change events."""

--- a/src/ytm_player/app/_sidebar.py
+++ b/src/ytm_player/app/_sidebar.py
@@ -190,8 +190,11 @@ class SidebarMixin(YTMHostBase):
     async def on_playlist_sidebar_nav_item_clicked(
         self, message: PlaylistSidebar.NavItemClicked
     ) -> None:
-        """Navigate to liked_songs or recently_played from sidebar pinned nav."""
-        await self.navigate_to(message.nav_id)
+        """Navigate to liked_songs or recently_played, or start discovery mix."""
+        if message.nav_id == "discovery_mix":
+            self.run_worker(self._start_discovery_mix(), exclusive=True)
+        else:
+            await self.navigate_to(message.nav_id)
 
     def _open_playlist_context_menu(self, item: dict) -> None:
         """Push ActionsPopup for a sidebar playlist item."""

--- a/src/ytm_player/app/_track_actions.py
+++ b/src/ytm_player/app/_track_actions.py
@@ -99,7 +99,7 @@ class TrackActionsMixin(YTMHostBase):
                 self._refresh_queue_page()
                 self.notify("Added to queue", timeout=2)
             elif action_id == "start_radio":
-                self.run_worker(self._start_radio_for(track))
+                self.run_worker(self._fetch_and_play_radio(track))
             elif action_id == "go_to_artist":
                 artists = track.get("artists", [])
                 if isinstance(artists, list) and artists:
@@ -171,26 +171,3 @@ class TrackActionsMixin(YTMHostBase):
     def on_playback_bar_track_right_clicked(self, message: PlaybackBar.TrackRightClicked) -> None:
         """Handle right-click on the playback bar -- open actions popup."""
         self._open_actions_for_track(message.track)
-
-    async def _start_radio_for(self, track: dict) -> None:
-        """Start radio from a specific track."""
-        video_id = get_video_id(track)
-        if not video_id or not self.ytmusic:
-            return
-
-        self.notify("Starting radio...", timeout=3)
-        try:
-            from ytm_player.utils.formatting import normalize_tracks
-
-            radio_tracks = normalize_tracks(await self.ytmusic.get_radio(video_id))
-        except Exception:
-            logger.exception("Failed to start radio")
-            self.notify("Failed to start radio", severity="error")
-            return
-
-        if radio_tracks:
-            self.queue.clear()
-            self.queue.set_radio_tracks(radio_tracks)
-            first = self.queue.next_track()
-            if first:
-                await self.play_track(first)

--- a/src/ytm_player/services/queue.py
+++ b/src/ytm_player/services/queue.py
@@ -99,6 +99,20 @@ class QueueManager:
     def shuffle_enabled(self) -> bool:
         return self._shuffle
 
+    @property
+    def real_index(self) -> int:
+        """Current index into _tracks regardless of shuffle mode."""
+        with self._lock:
+            return self._real_index()
+
+    @property
+    def remaining_tracks(self) -> int:
+        """Number of tracks remaining after the current position (shuffle-aware)."""
+        with self._lock:
+            if self._shuffle:
+                return len(self._shuffle_order) - self._shuffle_position - 1
+            return len(self._tracks) - self._current_index - 1
+
     # -- Helpers ----------------------------------------------------------
 
     def _real_index(self) -> int:

--- a/src/ytm_player/services/ytmusic.py
+++ b/src/ytm_player/services/ytmusic.py
@@ -143,6 +143,7 @@ class YTMusicService:
         # Serializes get_playlist(order=...) monkey-patches so concurrent
         # calls don't stack patches on client._send_request.
         self._order_lock = asyncio.Lock()
+        self._last_discovery_source: int = -1
 
     @property
     def client(self) -> YTMusic:
@@ -473,14 +474,194 @@ class YTMusicService:
             )
             return []
 
-    async def get_radio(self, video_id: str) -> list[dict[str, Any]]:
-        """Start a radio queue from a song and return its tracks."""
-        try:
-            result = await self._call(self.client.get_watch_playlist, videoId=video_id, radio=True)
-            return result.get("tracks", []) if isinstance(result, dict) else []
-        except Exception:
-            logger.exception("get_radio failed for %r", video_id)
+    async def get_radio(self, video_ids: str | list[str], limit: int = 25) -> list[dict]:
+        """Fetch radio tracks from one or more seeds and return a deduplicated mix.
+
+        Fetches all seeds in parallel. Individual seed failures are
+        swallowed so a single bad ID doesn't abort the batch.
+        Returns the pool normalized, shuffled, and trimmed to *limit*.
+        """
+        import random
+
+        from ytm_player.utils.formatting import normalize_tracks
+
+        if isinstance(video_ids, str):
+            video_ids = [video_ids]
+        if not video_ids:
             return []
+
+        async def _fetch_one(video_id: str) -> list[dict]:
+            try:
+                result = await self._call(
+                    self.client.get_watch_playlist, videoId=video_id, radio=True
+                )
+                return result.get("tracks", []) if isinstance(result, dict) else []
+            except Exception:
+                logger.debug("get_radio: seed %r failed, skipping", video_id)
+                return []
+
+        results = await asyncio.gather(*[_fetch_one(vid) for vid in video_ids])
+
+        pool: list[dict] = []
+        seen_ids: set[str] = set()
+        for tracks in results:
+            for track in tracks:
+                vid = track.get("videoId") or track.get("video_id", "")
+                if vid and vid not in seen_ids:
+                    seen_ids.add(vid)
+                    pool.append(track)
+
+        random.shuffle(pool)
+        return normalize_tracks(pool[:limit])
+
+    async def get_discovery_mix(self) -> tuple[list[dict], str]:
+        """Select seed tracks from one of seven sources for discovery playback.
+
+        Rotates sources — avoids repeating the last-used source.
+        Returns (seed_tracks, label).  On failure, tries a different
+        source as fallback.  Returns ([], "") if all fail.
+        """
+        import random
+
+        sources = [1, 2, 3, 4, 5, 6, 7]
+
+        if self._last_discovery_source in sources and len(sources) > 1:
+            sources.remove(self._last_discovery_source)
+
+        random.shuffle(sources)
+
+        async def _home_mix() -> tuple[list[dict], str]:
+            shelves = await self._call(self.client.get_home, limit=3)
+            all_playable: list[dict] = []
+            for shelf in shelves:
+                items = shelf.get("contents", []) if isinstance(shelf, dict) else []
+                all_playable.extend(i for i in items if isinstance(i, dict) and i.get("videoId"))
+            if not all_playable:
+                return [], ""
+            sampled = random.sample(all_playable, min(3, len(all_playable)))
+            label = sampled[0].get("title", "Home")
+            return sampled, f"Radio: {label}"
+
+        async def _trending_mix() -> tuple[list[dict], str]:
+            result = await self._call(self.client.get_explore)
+            playlist_id = result.get("trending", {}).get("playlist")
+            if not playlist_id:
+                return [], ""
+            wl = await self._call(
+                self.client.get_watch_playlist, playlistId=playlist_id, shuffle=True
+            )
+            items = wl.get("tracks", []) if isinstance(wl, dict) else []
+            playable = [t for t in items if isinstance(t, dict) and t.get("videoId")]
+            if not playable:
+                return [], ""
+            sampled = random.sample(playable, min(3, len(playable)))
+            label = sampled[0].get("title", "Trending")
+            return sampled, f"Radio: {label}"
+
+        async def _mood_mix() -> tuple[list[dict], str]:
+            categories_dict = await self._call(self.client.get_mood_categories)
+            if not categories_dict or not isinstance(categories_dict, dict):
+                return [], ""
+            section = random.choice(list(categories_dict.values()))
+            if not section:
+                return [], ""
+            category = random.choice(section)
+            params = category.get("params", "")
+            if not params:
+                return [], ""
+            playlists = await self._call(self.client.get_mood_playlists, params)
+            if not playlists:
+                return [], ""
+            playlist = random.choice(playlists)
+            playlist_id = playlist.get("playlistId", "")
+            if not playlist_id:
+                return [], ""
+            wl = await self._call(
+                self.client.get_watch_playlist, playlistId=playlist_id, shuffle=True
+            )
+            items = wl.get("tracks", []) if isinstance(wl, dict) else []
+            playable = [t for t in items if isinstance(t, dict) and t.get("videoId")]
+            if not playable:
+                return [], ""
+            sampled = random.sample(playable, min(3, len(playable)))
+            playlist_title = playlist.get("title", "")
+            label = sampled[0].get("title", playlist_title or "Mood")
+            return sampled, f"Radio: {label}"
+
+        async def _charts_mix() -> tuple[list[dict], str]:
+            charts = await self._call(self.client.get_charts)
+            videos = charts.get("videos", {})
+            items = videos.get("items", videos) if isinstance(videos, dict) else videos
+            if not items:
+                return [], ""
+            sampled = random.sample(items, min(3, len(items)))
+            playable = [v for v in sampled if v.get("videoId")]
+            if not playable:
+                return [], ""
+            label = playable[0].get("title", "Charts")
+            return playable, f"Radio: {label}"
+
+        async def _liked_songs_mix() -> tuple[list[dict], str]:
+            liked = await self._call(self.client.get_liked_songs, limit=50)
+            items = liked.get("tracks", []) if isinstance(liked, dict) else []
+            playable = [t for t in items if isinstance(t, dict) and t.get("videoId")]
+            if not playable:
+                return [], ""
+            sampled = random.sample(playable, min(3, len(playable)))
+            label = sampled[0].get("title", "Liked songs")
+            return sampled, f"Radio: {label}"
+
+        async def _artist_mix() -> tuple[list[dict], str]:
+            artists = await self._call(self.client.get_library_artists, limit=25)
+            if not artists:
+                return [], ""
+            artist = random.choice(artists)
+            channel_id = artist.get("browseId", "")
+            if not channel_id:
+                return [], ""
+            artist_data = await self._call(self.client.get_artist, channel_id)
+            songs = artist_data.get("songs", {})
+            results = songs.get("results", []) if isinstance(songs, dict) else []
+            playable = [t for t in results if isinstance(t, dict) and t.get("videoId")]
+            if not playable:
+                return [], ""
+            sampled = random.sample(playable, min(3, len(playable)))
+            artist_name = artist.get("artist", "Artist")
+            label = sampled[0].get("title", artist_name)
+            return sampled, f"{artist_name}: {label}"
+
+        async def _history_mix() -> tuple[list[dict], str]:
+            history = await self._call(self.client.get_history)
+            if not history:
+                return [], ""
+            playable = [t for t in history if isinstance(t, dict) and t.get("videoId")]
+            if not playable:
+                return [], ""
+            recent = playable[:20]
+            sampled = random.sample(recent, min(3, len(recent)))
+            label = sampled[0].get("title", "History")
+            return sampled, f"Radio: {label}"
+
+        _source_fns: dict[int, Any] = {
+            1: _trending_mix,
+            2: _mood_mix,
+            3: _charts_mix,
+            4: _home_mix,
+            5: _liked_songs_mix,
+            6: _artist_mix,
+            7: _history_mix,
+        }
+
+        for source in sources:
+            try:
+                seeds, label = await _source_fns[source]()
+                if seeds:
+                    self._last_discovery_source = source
+                    return seeds, label
+            except Exception:
+                logger.exception("get_discovery_mix: source %d failed", source)
+
+        return [], ""
 
     # ------------------------------------------------------------------
     # Library actions

--- a/src/ytm_player/ui/sidebars/playlist_sidebar.py
+++ b/src/ytm_player/ui/sidebars/playlist_sidebar.py
@@ -498,6 +498,7 @@ class PlaylistSidebar(Widget):
         with Vertical(id="ps-pinned-nav"):
             yield Static("\u2665 Liked Songs", id="ps-nav-liked", classes="ps-pinned-item")
             yield Static("\u23f1 Recently Played", id="ps-nav-recent", classes="ps-pinned-item")
+            yield Static("\u266b Discovery Mix", id="ps-nav-discovery", classes="ps-pinned-item")
         yield Rule(id="ps-separator")
         yield LibraryPanel("Playlists", id="ps-playlists", instant_select=True)
 
@@ -568,6 +569,9 @@ class PlaylistSidebar(Widget):
         elif target.id == "ps-nav-recent":
             event.stop()
             self.post_message(self.NavItemClicked("recently_played"))
+        elif target.id == "ps-nav-discovery":
+            event.stop()
+            self.post_message(self.NavItemClicked("discovery_mix"))
 
     # -- Public helpers for sidebar actions --
 

--- a/tests/test_services/test_queue.py
+++ b/tests/test_services/test_queue.py
@@ -376,3 +376,33 @@ class TestRadioTracks:
         ]
         queue_manager.set_radio_tracks(radio)
         assert queue_manager.length == 7
+
+
+class TestQueuePositionTracking:
+    """Tests for real_index and remaining_tracks properties."""
+
+    def test_real_index_without_shuffle(self, queue_manager, sample_tracks):
+        for t in sample_tracks:
+            queue_manager.add(t)
+        queue_manager.jump_to(2)
+        assert queue_manager.real_index == 2
+
+    def test_real_index_with_shuffle_resolves_to_tracks_index(self, queue_manager, sample_tracks):
+        for t in sample_tracks:
+            queue_manager.add(t)
+        queue_manager.toggle_shuffle()
+        queue_manager.jump_to(0)
+        assert 0 <= queue_manager.real_index < len(sample_tracks)
+
+    def test_remaining_tracks_without_shuffle(self, queue_manager, sample_tracks):
+        for t in sample_tracks:
+            queue_manager.add(t)
+        queue_manager.jump_to(2)
+        assert queue_manager.remaining_tracks == 2  # tracks 3 and 4
+
+    def test_remaining_tracks_with_shuffle(self, queue_manager, sample_tracks):
+        for t in sample_tracks:
+            queue_manager.add(t)
+        queue_manager.toggle_shuffle()
+        queue_manager.jump_to(0)
+        assert queue_manager.remaining_tracks == len(sample_tracks) - 1

--- a/tests/test_services/test_ytmusic_discovery_mix.py
+++ b/tests/test_services/test_ytmusic_discovery_mix.py
@@ -1,0 +1,157 @@
+"""Tests for YTMusicService.get_discovery_mix."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ytm_player.services.ytmusic import YTMusicService
+
+
+@pytest.fixture
+def svc():
+    s = YTMusicService.__new__(YTMusicService)
+    s._auth_path = Path(__file__)
+    s._auth_manager = None
+    s._user = None
+    s._consecutive_api_failures = 0
+    s._order_lock = asyncio.Lock()
+    s._last_discovery_source = -1
+    s._client_init_lock = MagicMock()
+    s._ytm = MagicMock()
+    return s
+
+
+class TestGetDiscoveryMix:
+    async def test_returns_seeds_and_label(self, svc):
+        """get_discovery_mix returns (seed_tracks, label) tuple."""
+
+        def force_trending_first(lst):
+            lst.sort(key=lambda x: 0 if x == 1 else 1)
+
+        with (
+            patch("random.shuffle", side_effect=force_trending_first),
+            patch.object(
+                svc,
+                "_call",
+                new_callable=AsyncMock,
+                side_effect=[
+                    {"trending": {"playlist": "PLtrend"}},
+                    {"tracks": [{"videoId": "t1", "title": "Hit Song"}]},
+                ],
+            ),
+        ):
+            seeds, label = await svc.get_discovery_mix()
+
+        assert isinstance(seeds, list)
+        assert len(seeds) > 0
+        assert all("videoId" in s for s in seeds)
+        assert label == "Radio: Hit Song"
+
+    async def test_source_rotation_via_shuffle(self, svc):
+        """Shuffled source list determines which source is tried first."""
+        charts_data = {"videos": {"items": [{"videoId": "chart1", "title": "Hot Song"}]}}
+
+        def force_charts_first(lst):
+            lst.sort(key=lambda x: 0 if x == 3 else 1)
+
+        with (
+            patch("random.shuffle", side_effect=force_charts_first),
+            patch.object(
+                svc,
+                "_call",
+                new_callable=AsyncMock,
+                return_value=charts_data,
+            ),
+        ):
+            seeds, label = await svc.get_discovery_mix()
+
+        assert label == "Radio: Hot Song"
+        assert len(seeds) > 0
+
+    async def test_fallback_iterates_sources(self, svc):
+        """If first source fails, iterates to the next in shuffled order."""
+        call_count = 0
+
+        async def mock_call(func, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("charts API down")
+            if call_count == 2:
+                return {"trending": {"playlist": "PL999"}}
+            return {"tracks": [{"videoId": "fb1", "title": "Fallback Song"}]}
+
+        def force_charts_then_trending(lst):
+            lst.sort(key=lambda x: {3: 0, 1: 1}.get(x, 2))
+
+        with (
+            patch("random.shuffle", side_effect=force_charts_then_trending),
+            patch.object(svc, "_call", side_effect=mock_call),
+        ):
+            seeds, label = await svc.get_discovery_mix()
+
+        assert label == "Radio: Fallback Song"
+        assert len(seeds) > 0
+
+    async def test_seeds_have_video_id(self, svc):
+        """Returned seeds have videoId keys (raw API format, not normalized)."""
+
+        def force_trending_first(lst):
+            lst.sort(key=lambda x: 0 if x == 1 else 1)
+
+        with (
+            patch("random.shuffle", side_effect=force_trending_first),
+            patch.object(
+                svc,
+                "_call",
+                new_callable=AsyncMock,
+                side_effect=[
+                    {"trending": {"playlist": "PL123"}},
+                    {"tracks": [{"videoId": "norm1", "title": "Song"}]},
+                ],
+            ),
+        ):
+            seeds, _ = await svc.get_discovery_mix()
+
+        assert all("videoId" in s for s in seeds)
+
+    async def test_all_sources_fail_returns_empty(self, svc):
+        """Returns ([], '') when all sources fail."""
+
+        async def always_fail(func, *args, **kwargs):
+            raise RuntimeError("API down")
+
+        with patch.object(svc, "_call", side_effect=always_fail):
+            seeds, label = await svc.get_discovery_mix()
+
+        assert seeds == []
+        assert label == ""
+
+    async def test_source_rotation_excludes_last(self, svc):
+        """The last-used source is excluded from the next call."""
+        svc._last_discovery_source = 2
+
+        captured_sources: list[int] = []
+
+        def capture_shuffle(lst):
+            captured_sources.extend(lst)
+
+        with (
+            patch("random.shuffle", side_effect=capture_shuffle),
+            patch.object(
+                svc,
+                "_call",
+                new_callable=AsyncMock,
+                side_effect=[
+                    {"trending": {"playlist": "PL1"}},
+                    {"tracks": [{"videoId": "r1", "title": "Song"}]},
+                ],
+            ),
+        ):
+            await svc.get_discovery_mix()
+
+        assert 2 not in captured_sources

--- a/tests/test_services/test_ytmusic_multi_seed_radio.py
+++ b/tests/test_services/test_ytmusic_multi_seed_radio.py
@@ -1,0 +1,135 @@
+"""Tests for YTMusicService.get_radio."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ytm_player.services.ytmusic import YTMusicService
+
+
+@pytest.fixture
+def svc():
+    """Construct YTMusicService bypassing __init__."""
+    s = YTMusicService.__new__(YTMusicService)
+    s._auth_path = None
+    s._auth_manager = None
+    s._user = None
+    s._consecutive_api_failures = 0
+    s._order_lock = asyncio.Lock()
+    s._client_init_lock = MagicMock()
+    s._ytm = MagicMock()
+    return s
+
+
+def _watch_result(video_ids: list[str]) -> dict:
+    return {"tracks": [{"videoId": vid, "title": f"Track {vid}"} for vid in video_ids]}
+
+
+class TestGetSeededRadio:
+    async def test_single_seed_returns_tracks(self, svc):
+        with patch.object(
+            svc,
+            "_call",
+            new_callable=AsyncMock,
+            return_value=_watch_result(["a", "b", "c"]),
+        ):
+            result = await svc.get_radio(["v1"])
+
+        assert len(result) > 0
+        result_ids = {t["video_id"] for t in result}
+        assert result_ids == {"a", "b", "c"}
+
+    async def test_deduplication_across_seeds(self, svc):
+        async def mock_call(func, **kwargs):
+            vid = kwargs.get("videoId", "")
+            results = {
+                "v1": _watch_result(["a", "b", "c"]),
+                "v2": _watch_result(["b", "c", "d"]),
+                "v3": _watch_result(["e"]),
+            }
+            return results.get(vid, {"tracks": []})
+
+        with patch.object(svc, "_call", side_effect=mock_call):
+            result = await svc.get_radio(["v1", "v2", "v3"])
+
+        result_ids = {t["video_id"] for t in result}
+        assert result_ids == {"a", "b", "c", "d", "e"}
+
+    async def test_no_seed_cap(self, svc):
+        """All seeds are used — no artificial cap."""
+        call_video_ids: list[str] = []
+
+        async def mock_call(func, **kwargs):
+            vid = kwargs.get("videoId", "")
+            call_video_ids.append(vid)
+            return _watch_result([f"{vid}_t"])
+
+        with patch.object(svc, "_call", side_effect=mock_call):
+            await svc.get_radio(["s1", "s2", "s3", "s4", "s5"])
+
+        assert set(call_video_ids) == {"s1", "s2", "s3", "s4", "s5"}
+
+    async def test_individual_seed_failure_does_not_abort(self, svc):
+        async def mock_call(func, **kwargs):
+            vid = kwargs.get("videoId", "")
+            if vid == "bad":
+                raise RuntimeError("API error")
+            return _watch_result([f"{vid}_track"])
+
+        with patch.object(svc, "_call", side_effect=mock_call):
+            result = await svc.get_radio(["bad", "good"])
+
+        result_ids = {t["video_id"] for t in result}
+        assert "good_track" in result_ids
+
+    async def test_result_trimmed_to_limit(self, svc):
+        with patch.object(
+            svc,
+            "_call",
+            new_callable=AsyncMock,
+            return_value=_watch_result([f"v{i}" for i in range(40)]),
+        ):
+            result = await svc.get_radio(["seed1"], limit=10)
+
+        assert len(result) == 10
+
+    async def test_empty_seeds_returns_empty(self, svc):
+        call_count = 0
+
+        async def mock_call(func, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return {"tracks": []}
+
+        with patch.object(svc, "_call", side_effect=mock_call):
+            result = await svc.get_radio([])
+
+        assert result == []
+        assert call_count == 0
+
+    async def test_all_seeds_fail_returns_empty(self, svc):
+        async def mock_call(func, **kwargs):
+            raise RuntimeError("failure")
+
+        with patch.object(svc, "_call", side_effect=mock_call):
+            result = await svc.get_radio(["s1", "s2", "s3"])
+
+        assert result == []
+
+    async def test_handles_both_video_id_key_formats(self, svc):
+        """Dedup works with both videoId and video_id keys."""
+
+        async def mock_call(func, **kwargs):
+            vid = kwargs.get("videoId", "")
+            if vid == "v1":
+                return {"tracks": [{"videoId": "shared"}]}
+            return {"tracks": [{"video_id": "shared"}]}
+
+        with patch.object(svc, "_call", side_effect=mock_call):
+            result = await svc.get_radio(["v1", "v2"])
+
+        ids = [t.get("video_id") for t in result]
+        assert ids.count("shared") == 1


### PR DESCRIPTION
## Summary
- Autoplay silently refills the queue before it runs dry, seeded from recently-played tracks
- Discovery Mix sidebar item plays a random mix from home picks, trending, moods, charts, liked songs, library artists, or listening history
- Radio requests use multiple seeds for better variety and deduplicate across seeds