### PR TITLE
fix(stream): adds android client fallback for restricted content

### DIFF
--- a/src/ytm_player/services/stream.py
+++ b/src/ytm_player/services/stream.py
@@ -85,6 +85,7 @@ class StreamResolver:
             # Avoid writing any files to disk.
             "writeinfojson": False,
             "writethumbnail": False,
+            "extractor_args": {"youtube": {"player_client": ["default", "android"]}},
         }
         return apply_configured_yt_dlp_options(opts, settings)
 


### PR DESCRIPTION
## Summary
- Adds android as a fallback player client in yt-dlp extractor_args
- Children's content (madeForKids) and other restricted videos that fail on the default web client now transparently fall back to the android client
- Normal songs still resolve via the default client at full audio quality