### PR TITLE
refactor(ui): migrate Queue, Liked Songs, Recently Played to TrackTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,16 +131,14 @@ A reliability and quality release driven by a multi-agent expert audit. Hardens 
 
 **New**
 
-- Playlist radio — right-click any sidebar playlist and choose "Start Radio", or click the "[▶ Start Radio]" button in the playlist header (Library and Context pages). Seeds a radio queue via `RDAMPL` + playlist ID.
-- "Add to Library" button now only shows for playlists you don't own. Both header buttons were previously invisible due to a layout bug (Label taking full width); fixed with `width: auto`.
-- Configurable home shelf count — set `home_shelves` under `[ui]` in `config.toml` to control how many recommendation shelves are fetched on the Browse > For You tab (default: 3, range: 1–25).
-- For You shelves scroll as a single section instead of each shelf scrolling independently, with subtle separators and colored section titles for readability.
+- Queue, Liked Songs, and Recently Played pages migrated from raw DataTable to TrackTable — gains right-click context menus, play indicators, column resize, filtering, and sorting
+- `[▶ Start Radio]` button in Liked Songs and Recently Played page headers — seeds radio from 5 random tracks in the collection
+- Shuffle-lock integration for Liked Songs and Recently Played — selecting a track applies the per-collection shuffle preference
 
 **Fixes**
 
-- macOS built-in keyboard media keys (prev/next) now work — built-in MacBook keyboards send key codes 19/20 (fast-forward/rewind) instead of the standard 17/18 (next/previous) that external keyboards use. The Quartz event tap now maps both sets.
-- Browse tab bar now renders correctly — `.tab-item` height increased from 1 to 3 rows so text is visible, tabs sized with `width: auto` so all four render side-by-side, hover state added for discoverability, and tab bar background set to `$surface` for contrast.
-- yt-dlp now also tries the android client when the default web client refuses (e.g., madeForKids content); falls through to a non-PoT legacy format that succeeds. Normal songs unaffected.
+- Radio track durations no longer show `--:--` — ytmusicapi's `get_watch_playlist` returns duration as `length` (e.g. "3:07") instead of `duration`; `extract_duration` now checks all three keys
+- Play history no longer stores duration as 0 — `log_play` was using `duration_seconds` but normalized tracks store `duration`; fixed with `extract_duration()`
 
 ---
 

--- a/src/ytm_player/services/history.py
+++ b/src/ytm_player/services/history.py
@@ -188,11 +188,13 @@ class HistoryManager:
         if self._db is None:
             raise RuntimeError("Database not initialized")
 
+        from ytm_player.utils.formatting import extract_duration
+
         video_id = track["video_id"]
         title = track.get("title", "")
         artist = track.get("artist", "")
         album = track.get("album", "")
-        duration = track.get("duration_seconds", 0)
+        duration = extract_duration(track)
 
         try:
             await self._db.execute(

--- a/src/ytm_player/ui/pages/liked_songs.py
+++ b/src/ytm_player/ui/pages/liked_songs.py
@@ -3,23 +3,21 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 from textual.app import ComposeResult
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
+from textual.events import Click
 from textual.reactive import reactive
 from textual.widget import Widget
-from textual.widgets import DataTable, Input, Label, Static
-from textual.widgets.data_table import RowKey
+from textual.widgets import Input, Label, Static
 
 from ytm_player.config.keymap import Action
-from ytm_player.config.settings import get_settings
-from ytm_player.utils.formatting import (
-    extract_artist,
-    extract_duration,
-    format_duration,
-    normalize_tracks,
-)
+from ytm_player.ui.widgets.track_table import TrackTable
+from ytm_player.utils.formatting import normalize_tracks
+
+if TYPE_CHECKING:
+    from ytm_player.app._base import YTMHostBase
 
 logger = logging.getLogger(__name__)
 
@@ -39,16 +37,27 @@ class LikedSongsPage(Widget):
         padding: 1 2;
         background: $surface;
     }
+    .liked-header-row {
+        height: auto;
+        width: 1fr;
+    }
+    .liked-header-row Label {
+        width: auto;
+    }
     .liked-header-title {
         text-style: bold;
         color: $primary;
     }
-    .liked-table {
-        height: 1fr;
-        width: 1fr;
+    #start-radio-btn {
+        width: auto;
+        min-width: 14;
+        height: 1;
+        margin: 0 0 0 1;
+        padding: 0 1;
+        color: $primary;
     }
-    .liked-table > .datatable--cursor {
-        background: $selected-item;
+    #start-radio-btn:hover {
+        background: $primary 30%;
     }
     .liked-footer {
         height: 1;
@@ -75,41 +84,20 @@ class LikedSongsPage(Widget):
 
     def __init__(self, *, cursor_row: int | None = None, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self._row_keys: list[RowKey] = []
-        self._tracks: list[dict] = []
-        self._filtered_indices: list[int] = []
-        self._filter_text: str = ""
-        self._filter_timer: Any = None
         self._restore_cursor_row = cursor_row
 
     def compose(self) -> ComposeResult:
-        yield Vertical(
-            Label("Liked Songs", classes="liked-header-title"),
-            id="liked-header",
-            classes="liked-header",
-        )
+        with Vertical(id="liked-header", classes="liked-header"):
+            with Horizontal(classes="liked-header-row"):
+                yield Label("Liked Songs", classes="liked-header-title")
+                yield Static("[▶ Start Radio]", id="start-radio-btn", markup=True)
         yield Label("Loading liked songs...", id="liked-loading", classes="liked-loading")
-        yield DataTable(
-            cursor_type="row",
-            zebra_stripes=True,
-            id="liked-table",
-            classes="liked-table",
-        )
+        yield TrackTable(show_album=False, id="liked-table")
         yield Static("", id="liked-footer", classes="liked-footer")
         yield Input(placeholder="/ Filter tracks...", id="track-filter", classes="track-filter")
 
     def on_mount(self) -> None:
-        table = self.query_one("#liked-table", DataTable)
-        ui = get_settings().ui
-
-        def w(v: int) -> int | None:
-            return v if v > 0 else None
-
-        table.add_column("#", width=w(ui.col_index), key="index")
-        table.add_column("Title", width=w(ui.col_title), key="title")
-        table.add_column("Artist", width=w(ui.col_artist), key="artist")
-        table.add_column("Duration", width=w(ui.col_duration), key="duration")
-        table.display = False
+        self.query_one("#liked-table", TrackTable).display = False
         self.run_worker(self._load_liked_songs(), group="liked-load")
 
     # First batch size for progressive loading.
@@ -123,25 +111,23 @@ class LikedSongsPage(Widget):
 
         try:
             raw_tracks = await ytmusic.get_liked_songs(limit=self._FIRST_BATCH)
-            self._tracks = normalize_tracks(raw_tracks)
+            tracks = normalize_tracks(raw_tracks)
         except Exception:
             logger.exception("Failed to load liked songs")
-            self._tracks = []
+            tracks = []
 
-        self._refresh_table()
+        self._display_tracks(tracks)
 
         # Kick off background fetch if the first batch was full (likely more tracks).
-        if len(self._tracks) >= self._FIRST_BATCH:
+        if len(tracks) >= self._FIRST_BATCH:
             self._update_footer(loading_more=True)
             self.run_worker(self._fetch_remaining_liked(), group="liked-remaining")
 
-    def _refresh_table(self, loading_more: bool = False) -> None:
-        table = self.query_one("#liked-table", DataTable)
+    def _display_tracks(self, tracks: list[dict]) -> None:
+        table = self.query_one("#liked-table", TrackTable)
         loading = self.query_one("#liked-loading", Label)
-        table.clear()
-        self._row_keys = []
 
-        if not self._tracks:
+        if not tracks:
             table.display = False
             loading.update("No liked songs found.")
             loading.display = True
@@ -149,22 +135,10 @@ class LikedSongsPage(Widget):
 
         loading.display = False
         table.display = True
+        table.load_tracks(tracks)
 
-        # Build the visible (possibly filtered) list and index map.
-        self._filtered_indices = []
-        for i, track in enumerate(self._tracks):
-            if self._filter_text and not self._matches_filter(track, self._filter_text):
-                continue
-            self._filtered_indices.append(i)
-            title = track.get("title", "Unknown")
-            artist = extract_artist(track)
-            dur = extract_duration(track)
-            dur_str = format_duration(dur) if dur else "--:--"
-            row_key = table.add_row(str(i + 1), title, artist, dur_str, key=f"liked_{i}")
-            self._row_keys.append(row_key)
-
-        self.track_count = len(self._tracks)
-        self._update_footer(loading_more=loading_more)
+        self.track_count = len(tracks)
+        self._update_footer()
 
         # Restore cursor position from navigation state.
         row = self._restore_cursor_row
@@ -174,24 +148,15 @@ class LikedSongsPage(Widget):
 
     def _update_footer(self, loading_more: bool = False) -> None:
         try:
+            table = self.query_one("#liked-table", TrackTable)
             footer = self.query_one("#liked-footer", Static)
-            total = len(self._tracks)
-            shown = len(self._filtered_indices) if self._filter_text else total
-            if self._filter_text:
-                text = f"{shown}/{total} liked songs"
-            else:
-                text = f"{total} liked songs"
+            total = table.track_count
+            text = f"{total} liked songs"
             if loading_more:
                 text += " (loading more…)"
             footer.update(text)
         except Exception:
             pass
-
-    @staticmethod
-    def _matches_filter(track: dict, query: str) -> bool:
-        title = (track.get("title") or "").lower()
-        artist = extract_artist(track).lower()
-        return query in title or query in artist
 
     async def _fetch_remaining_liked(self) -> None:
         """Background fetch for liked songs beyond the first batch."""
@@ -209,51 +174,40 @@ class LikedSongsPage(Widget):
             self._update_footer()
             return
 
-        # Slice off the tracks we already have.
-        remaining_raw = remaining_raw[len(self._tracks) :]
+        table = self.query_one("#liked-table", TrackTable)
+        already_have = table.track_count
+
+        remaining_raw = remaining_raw[already_have:]
         if not remaining_raw:
             self._update_footer()
             return
 
         remaining = normalize_tracks(remaining_raw)
-        self._tracks.extend(remaining)
-        # Rebuild table to honor any active filter while keeping current scroll/cursor.
-        try:
-            self._refresh_table()
-        except Exception:
-            logger.debug("Failed to append remaining liked songs", exc_info=True)
+        table.append_tracks(remaining)
+        self.track_count = table.track_count
+        self._update_footer()
 
     def get_nav_state(self) -> dict[str, Any]:
         """Return state to preserve when navigating away."""
         state: dict[str, Any] = {}
         try:
-            table = self.query_one("#liked-table", DataTable)
+            table = self.query_one("#liked-table", TrackTable)
             if table.cursor_row is not None and table.cursor_row > 0:
                 state["cursor_row"] = table.cursor_row
         except Exception:
             pass
         return state
 
-    def _resolve_row_idx(self, row: int) -> int | None:
-        """Map a visible row index to the original index in self._tracks."""
-        if self._filter_text:
-            if 0 <= row < len(self._filtered_indices):
-                return self._filtered_indices[row]
-            return None
-        if 0 <= row < len(self._tracks):
-            return row
-        return None
-
-    async def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+    async def on_track_table_track_selected(self, event: TrackTable.TrackSelected) -> None:
         event.stop()
-        idx = self._resolve_row_idx(event.cursor_row)
-        if idx is not None:
-            queue = self.app.queue  # type: ignore[attr-defined]
-            queue.clear()
-            queue.add_multiple(self._tracks)
-            queue.jump_to_real(idx)
-            self._apply_shuffle_pref(queue)
-            await self.app.play_track(self._tracks[idx])  # type: ignore[attr-defined]
+        table = self.query_one("#liked-table", TrackTable)
+        tracks = table.tracks
+        host = cast("YTMHostBase", self.app)
+        host.queue.clear()
+        host.queue.add_multiple(tracks)
+        host.queue.jump_to_real(event.index)
+        self._apply_shuffle_pref(host.queue)
+        await host.play_track(event.track)
 
     _CONTEXT_ID = "__LIKED_SONGS__"
 
@@ -266,61 +220,42 @@ class LikedSongsPage(Widget):
             queue.toggle_shuffle()
 
     async def handle_action(self, action: Action, count: int = 1) -> None:
-        table = self.query_one("#liked-table", DataTable)
+        table = self.query_one("#liked-table", TrackTable)
 
         match action:
-            case Action.MOVE_DOWN:
-                for _ in range(count):
-                    table.action_cursor_down()
-            case Action.MOVE_UP:
-                for _ in range(count):
-                    table.action_cursor_up()
-            case Action.PAGE_DOWN:
-                table.action_scroll_down()
-            case Action.PAGE_UP:
-                table.action_scroll_up()
-            case Action.GO_TOP:
-                if table.row_count > 0:
-                    table.move_cursor(row=0)
-            case Action.GO_BOTTOM:
-                if table.row_count > 0:
-                    table.move_cursor(row=table.row_count - 1)
-            case Action.JUMP_TO_CURRENT:
-                queue = self.app.queue  # type: ignore[attr-defined]
-                current = queue.current_track if queue else None
-                if current and current.get("video_id"):
-                    vid = current["video_id"]
-                    # Find in visible (possibly filtered) rows.
-                    visible = (
-                        [self._tracks[i] for i in self._filtered_indices]
-                        if self._filter_text
-                        else self._tracks
-                    )
-                    for i, t in enumerate(visible):
-                        if t.get("video_id") == vid:
-                            table.move_cursor(row=i)
-                            break
-            case Action.SELECT:
-                idx = self._resolve_row_idx(table.cursor_row)
-                if idx is not None:
-                    queue = self.app.queue  # type: ignore[attr-defined]
-                    queue.clear()
-                    queue.add_multiple(self._tracks)
-                    queue.jump_to_real(idx)
-                    self._apply_shuffle_pref(queue)
-                    await self.app.play_track(self._tracks[idx])  # type: ignore[attr-defined]
             case Action.ADD_TO_QUEUE:
-                idx = self._resolve_row_idx(table.cursor_row)
-                if idx is not None:
-                    queue = self.app.queue  # type: ignore[attr-defined]
-                    queue.add(self._tracks[idx])
+                track = table.selected_track
+                if track:
+                    host = cast("YTMHostBase", self.app)
+                    host.queue.add(track)
                     self.app.notify("Added to queue", timeout=2)
-            case Action.FILTER:
-                self._show_filter()
+            case Action.TRACK_ACTIONS:
+                track = table.selected_track
+                if track:
+                    host = cast("YTMHostBase", self.app)
+                    host._open_actions_for_track(track)
+            case _:
+                await table.handle_action(action, count)
 
-    # ── Filter wiring ────────────────────────────────────────────────
+    def on_click(self, event: Click) -> None:
+        if event.widget is not None and event.widget.id == "start-radio-btn":
+            event.stop()
+            self.run_worker(self._start_radio(), name="start_radio", exclusive=True)
 
-    def _show_filter(self) -> None:
+    async def _start_radio(self) -> None:
+        import random
+
+        table = self.query_one("#liked-table", TrackTable)
+        tracks = table.tracks
+        if not tracks:
+            return
+        seeds = random.sample(tracks, min(5, len(tracks)))
+        seed_list = "\n".join(f"  • {s.get('title', 'Unknown')}" for s in seeds)
+        host = cast("YTMHostBase", self.app)
+        await host._fetch_and_play_radio(seeds, label=f"Radio: Liked Songs\n{seed_list}")
+
+    def on_track_table_filter_requested(self, event: TrackTable.FilterRequested) -> None:
+        event.stop()
         try:
             f = self.query_one("#track-filter", Input)
             f.value = ""
@@ -329,36 +264,27 @@ class LikedSongsPage(Widget):
         except Exception:
             pass
 
-    def _hide_filter(self) -> None:
+    def on_track_table_filter_closed(self, event: TrackTable.FilterClosed) -> None:
+        event.stop()
         try:
             f = self.query_one("#track-filter", Input)
             f.remove_class("visible")
-            self.query_one("#liked-table", DataTable).focus()
+            self.query_one("#liked-table", TrackTable).focus()
         except Exception:
             pass
 
-    def _apply_filter(self, query: str) -> None:
-        self._filter_text = query.strip().lower()
-        # Cancel any pending debounce timer.
-        if self._filter_timer is not None:
-            try:
-                self._filter_timer.stop()
-            except Exception:
-                pass
-            self._filter_timer = None
-        # Empty query: refresh immediately.
-        if not self._filter_text:
-            self._refresh_table()
-            return
-        self._filter_timer = self.set_timer(0.15, self._refresh_table)
-
     def on_input_changed(self, event: Input.Changed) -> None:
         if event.input.id == "track-filter":
-            self._apply_filter(event.value)
+            self.query_one("#liked-table", TrackTable).apply_filter(event.value)
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         if event.input.id == "track-filter":
-            self._hide_filter()
+            try:
+                f = self.query_one("#track-filter", Input)
+                f.remove_class("visible")
+                self.query_one("#liked-table", TrackTable).focus()
+            except Exception:
+                pass
 
     def on_key(self, event: object) -> None:
         from textual.events import Key
@@ -371,8 +297,8 @@ class LikedSongsPage(Widget):
                 if f.has_class("visible"):
                     event.stop()
                     event.prevent_default()
-                    self._filter_text = ""
-                    self._refresh_table()
-                    self._hide_filter()
+                    self.query_one("#liked-table", TrackTable).clear_filter()
+                    f.remove_class("visible")
+                    self.query_one("#liked-table", TrackTable).focus()
             except Exception:
                 pass

--- a/src/ytm_player/ui/pages/queue.py
+++ b/src/ytm_player/ui/pages/queue.py
@@ -3,18 +3,20 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.reactive import reactive
 from textual.widget import Widget
-from textual.widgets import DataTable, Input, Label, Static
-from textual.widgets.data_table import RowKey
+from textual.widgets import Input, Label, Static
 
 from ytm_player.config.keymap import Action
 from ytm_player.services.player import PlayerEvent
-from ytm_player.utils.formatting import extract_artist, extract_duration, format_duration
+from ytm_player.ui.widgets.track_table import TrackTable
+
+if TYPE_CHECKING:
+    from ytm_player.app._base import YTMHostBase
 
 logger = logging.getLogger(__name__)
 
@@ -46,13 +48,6 @@ class QueuePage(Widget):
     .queue-now-playing-artist {
         color: $text-muted;
     }
-    .queue-table {
-        height: 1fr;
-        width: 1fr;
-    }
-    .queue-table > .datatable--cursor {
-        background: $selected-item;
-    }
     .queue-footer {
         height: 1;
         padding: 0 2;
@@ -78,33 +73,16 @@ class QueuePage(Widget):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self._row_keys: list[RowKey] = []
-        self._playing_row: int | None = None  # tracks last play indicator position
         self._track_change_callback: Any = None
-        # Filter state — maps visible row index → real queue index.
-        self._filter_text: str = ""
-        self._filtered_indices: list[int] = []
-        self._filter_timer: Any = None
 
     def compose(self) -> ComposeResult:
         yield Vertical(id="queue-header", classes="queue-now-playing")
         yield Label("Queue is empty.", id="queue-empty", classes="queue-empty")
-        yield DataTable(
-            cursor_type="row",
-            zebra_stripes=True,
-            id="queue-table",
-            classes="queue-table",
-        )
+        yield TrackTable(show_album=False, id="queue-table")
         yield Static("", id="queue-footer", classes="queue-footer")
         yield Input(placeholder="/ Filter tracks...", id="track-filter", classes="track-filter")
 
     def on_mount(self) -> None:
-        table = self.query_one("#queue-table", DataTable)
-        table.add_column("#", width=4, key="index")
-        table.add_column("Title", width=None, key="title")
-        table.add_column("Artist", width=None, key="artist")
-        table.add_column("Duration", width=8, key="duration")
-
         self._register_player_events()
         self._refresh_queue()
 
@@ -129,9 +107,6 @@ class QueuePage(Widget):
     def _on_track_change(self, _track_info: dict) -> None:
         """Update the queue display when the track changes.
 
-        Does a lightweight update (header + play indicator) instead of
-        rebuilding the entire DataTable.
-
         Player events are dispatched onto the asyncio loop via
         ``call_soon_threadsafe`` (see services/player.py), so this
         callback already runs on the main thread — call directly.
@@ -142,14 +117,8 @@ class QueuePage(Widget):
             logger.debug("Failed to update queue page on track change", exc_info=True)
 
     def _update_current_track(self) -> None:
-        """Lightweight update: refresh header and play indicator without rebuilding the table.
-
-        Player events are dispatched onto the asyncio loop via
-        ``call_soon_threadsafe`` (see services/player.py), so this
-        callback already runs on the main thread — call directly.
-        """
+        """Lightweight update: refresh header and play indicator without rebuilding the table."""
         queue = self.app.queue  # type: ignore[attr-defined]
-        new_index = queue.current_index
         current_track = queue.current_track
 
         # Update the "Now Playing" header.
@@ -164,36 +133,20 @@ class QueuePage(Widget):
         else:
             header.display = False
 
-        # Only update the previous and new play-indicator cells (O(1) not O(n)).
-        table = self.query_one("#queue-table", DataTable)
-        old_index = self._playing_row
-
-        if old_index == new_index:
-            return  # Cursor is already showing the right row — no-op.
-
-        # Restore the old row's index number.
-        if old_index is not None and 0 <= old_index < len(self._row_keys):
-            try:
-                table.update_cell(self._row_keys[old_index], "index", str(old_index + 1))
-            except Exception:
-                logger.debug("Failed to restore old play indicator", exc_info=True)
-
-        # Set the play indicator on the new row.
-        if new_index is not None and 0 <= new_index < len(self._row_keys):
-            try:
-                table.update_cell(self._row_keys[new_index], "index", "\u25b6")
-            except Exception:
-                logger.debug("Failed to set play indicator", exc_info=True)
-
-        self._playing_row = new_index
+        # Update the playing indicator via TrackTable.
+        video_id = current_track.get("video_id", "") if current_track else None
+        try:
+            table = self.query_one("#queue-table", TrackTable)
+            table.set_playing(video_id)
+        except Exception:
+            logger.debug("Failed to update playing indicator", exc_info=True)
 
     # ── Queue rendering ───────────────────────────────────────────────
 
     def _refresh_queue(self) -> None:
         """Rebuild the entire queue display from the QueueManager state."""
         queue = self.app.queue  # type: ignore[attr-defined]
-        tracks = queue.tracks
-        current_index = queue.current_index
+        tracks = list(queue.tracks)
         current_track = queue.current_track
 
         # Update the "Now Playing" header.
@@ -208,41 +161,21 @@ class QueuePage(Widget):
         else:
             header.display = False
 
-        # Build the queue table with upcoming tracks (everything except current).
-        table = self.query_one("#queue-table", DataTable)
-        table.clear()
-        self._row_keys = []
-        self._filtered_indices = []
+        table = self.query_one("#queue-table", TrackTable)
 
-        # Show all tracks; the current one gets a play indicator.
         if not tracks:
             table.display = False
             self.query_one("#queue-empty").display = True
         else:
             table.display = True
             self.query_one("#queue-empty").display = False
+            table.load_tracks(tracks)
 
-            for i, track in enumerate(tracks):
-                if self._filter_text and not self._matches_filter(track, self._filter_text):
-                    continue
-                self._filtered_indices.append(i)
-                title = track.get("title", "Unknown")
-                artist = extract_artist(track)
-                dur = extract_duration(track)
-                dur_str = format_duration(dur) if dur else "--:--"
-                indicator = "\u25b6" if i == current_index else str(i + 1)
-
-                row_key = table.add_row(
-                    indicator,
-                    title,
-                    artist,
-                    dur_str,
-                    key=f"q_{i}",
-                )
-                self._row_keys.append(row_key)
+            # Set the playing indicator on the current track.
+            video_id = current_track.get("video_id", "") if current_track else None
+            table.set_playing(video_id)
 
         self.queue_length = len(tracks)
-        self._playing_row = current_index
         self._update_footer()
 
     def _update_footer(self) -> None:
@@ -257,82 +190,32 @@ class QueuePage(Widget):
         except Exception:
             logger.debug("Failed to update queue footer", exc_info=True)
 
-    # ── DataTable events ──────────────────────────────────────────────
+    # ── Track selection ───────────────────────────────────────────────
 
-    async def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+    async def on_track_table_track_selected(self, event: TrackTable.TrackSelected) -> None:
         """Jump to and play the selected track."""
         event.stop()
-        idx = self._resolve_row_idx(event.cursor_row)
-        if idx is None:
-            return
         queue = self.app.queue  # type: ignore[attr-defined]
-        track = queue.jump_to(idx)
+        track = queue.jump_to(event.index)
         if track:
-            await self.app.play_track(track)  # type: ignore[attr-defined]
+            host = cast("YTMHostBase", self.app)
+            await host.play_track(track)
             self._refresh_queue()
 
     # ── Action handling ───────────────────────────────────────────────
 
     async def handle_action(self, action: Action, count: int = 1) -> None:
         """Process vim-style navigation and queue management actions."""
-        table = self.query_one("#queue-table", DataTable)
+        table = self.query_one("#queue-table", TrackTable)
         queue = self.app.queue  # type: ignore[attr-defined]
 
         match action:
-            case Action.MOVE_DOWN:
-                for _ in range(count):
-                    table.action_cursor_down()
-
-            case Action.MOVE_UP:
-                for _ in range(count):
-                    table.action_cursor_up()
-
-            case Action.PAGE_DOWN:
-                table.action_scroll_down()
-
-            case Action.PAGE_UP:
-                table.action_scroll_up()
-
-            case Action.GO_TOP:
-                if table.row_count > 0:
-                    table.move_cursor(row=0)
-
-            case Action.GO_BOTTOM:
-                if table.row_count > 0:
-                    table.move_cursor(row=table.row_count - 1)
-
-            case Action.JUMP_TO_CURRENT:
-                # Find the current queue index in the visible (filtered) rows.
-                cur = queue.current_index
-                if cur is not None:
-                    if self._filter_text:
-                        for visible_row, real_idx in enumerate(self._filtered_indices):
-                            if real_idx == cur:
-                                table.move_cursor(row=visible_row)
-                                break
-                    elif 0 <= cur < table.row_count:
-                        table.move_cursor(row=cur)
-
-            case Action.SELECT:
-                idx = self._resolve_row_idx(table.cursor_row)
-                if idx is not None:
-                    track = queue.jump_to(idx)
-                    if track:
-                        await self.app.play_track(track)  # type: ignore[attr-defined]
-                        self._refresh_queue()
-
-            # Remove selected track from queue (d d / delete key).
             case Action.DELETE_ITEM:
                 self._remove_selected(table, queue)
 
-            case Action.FILTER:
-                self._show_filter()
-
-            # Reorder: move track up (C-k).
             case Action.FOCUS_PREV if self._is_reorder_context():
                 self._move_track(table, queue, direction=-1)
 
-            # Reorder: move track down (C-j).
             case Action.FOCUS_NEXT if self._is_reorder_context():
                 self._move_track(table, queue, direction=1)
 
@@ -344,87 +227,49 @@ class QueuePage(Widget):
             # app/_keys.py and never delegated here, so no QueuePage case
             # for it.
 
+            case Action.TRACK_ACTIONS:
+                track = table.selected_track
+                if track:
+                    host = cast("YTMHostBase", self.app)
+                    host._open_actions_for_track(track)
+
+            case _:
+                await table.handle_action(action, count)
+
     def _is_reorder_context(self) -> bool:
         """Always allow reorder in the queue page."""
         return True
 
-    def on_mouse_down(self, event: Any) -> None:
-        """Forward right-click on the queue table to the app's actions popup.
-
-        Queue page uses a raw DataTable (not TrackTable), so the
-        right-click → actions popup wiring on TrackTable doesn't apply.
-        We use the cursor row (right-click typically lands on the
-        currently-highlighted row).
-        """
-        if getattr(event, "button", 1) != 3:
-            return
-        try:
-            table = self.query_one("#queue-table", DataTable)
-            row = table.cursor_row
-            idx = self._resolve_row_idx(row)
-            if idx is None:
-                return
-            queue = self.app.queue  # type: ignore[attr-defined]
-            if not (0 <= idx < queue.length):
-                return
-            track = queue.tracks[idx]
-            self.app._open_actions_for_track(track)  # type: ignore[attr-defined]
-            event.stop()
-        except Exception:
-            logger.debug("Failed to open queue actions popup", exc_info=True)
-
-    def _remove_selected(self, table: DataTable, queue: Any) -> None:
+    def _remove_selected(self, table: TrackTable, queue: Any) -> None:
         """Remove the currently highlighted track from the queue."""
-        idx = self._resolve_row_idx(table.cursor_row)
-        if idx is None:
+        track = table.selected_track
+        if not track:
             return
-        if 0 <= idx < queue.length:
+        # Find the track's real index in the queue.
+        idx = table.cursor_row
+        if idx is not None and 0 <= idx < queue.length:
             queue.remove(idx)
             self._refresh_queue()
-            # Keep cursor in bounds after removal.
             if table.row_count > 0:
-                visible_row = table.cursor_row
-                if visible_row is not None:
-                    new_row = min(visible_row, table.row_count - 1)
-                    table.move_cursor(row=new_row)
+                new_row = min(idx, table.row_count - 1)
+                table.move_cursor(row=new_row)
 
-    def _move_track(self, table: DataTable, queue: Any, direction: int) -> None:
+    def _move_track(self, table: TrackTable, queue: Any, direction: int) -> None:
         """Move the highlighted track up or down in the queue."""
-        from_idx = self._resolve_row_idx(table.cursor_row)
-        if from_idx is None:
+        if table.cursor_row is None:
             return
+        from_idx = table.cursor_row
         to_idx = from_idx + direction
         if not (0 <= to_idx < queue.length):
             return
         queue.move(from_idx, to_idx)
         self._refresh_queue()
-        # When unfiltered, the cursor follows the moved row; when filtered,
-        # the visible position may not match — keep cursor where it was.
-        if not self._filter_text:
-            table.move_cursor(row=to_idx)
+        table.move_cursor(row=to_idx)
 
-    # ── Filter helpers ───────────────────────────────────────────────
+    # ── Filter wiring ────────────────────────────────────────────────
 
-    def _resolve_row_idx(self, row: int | None) -> int | None:
-        """Map a visible row index to the real queue index."""
-        if row is None:
-            return None
-        if self._filter_text:
-            if 0 <= row < len(self._filtered_indices):
-                return self._filtered_indices[row]
-            return None
-        queue = self.app.queue  # type: ignore[attr-defined]
-        if 0 <= row < queue.length:
-            return row
-        return None
-
-    @staticmethod
-    def _matches_filter(track: dict, query: str) -> bool:
-        title = (track.get("title") or "").lower()
-        artist = extract_artist(track).lower()
-        return query in title or query in artist
-
-    def _show_filter(self) -> None:
+    def on_track_table_filter_requested(self, event: TrackTable.FilterRequested) -> None:
+        event.stop()
         try:
             f = self.query_one("#track-filter", Input)
             f.value = ""
@@ -433,34 +278,27 @@ class QueuePage(Widget):
         except Exception:
             pass
 
-    def _hide_filter(self) -> None:
+    def on_track_table_filter_closed(self, event: TrackTable.FilterClosed) -> None:
+        event.stop()
         try:
             f = self.query_one("#track-filter", Input)
             f.remove_class("visible")
-            self.query_one("#queue-table", DataTable).focus()
+            self.query_one("#queue-table", TrackTable).focus()
         except Exception:
             pass
 
-    def _apply_filter(self, query: str) -> None:
-        self._filter_text = query.strip().lower()
-        if self._filter_timer is not None:
-            try:
-                self._filter_timer.stop()
-            except Exception:
-                pass
-            self._filter_timer = None
-        if not self._filter_text:
-            self._refresh_queue()
-            return
-        self._filter_timer = self.set_timer(0.15, self._refresh_queue)
-
     def on_input_changed(self, event: Input.Changed) -> None:
         if event.input.id == "track-filter":
-            self._apply_filter(event.value)
+            self.query_one("#queue-table", TrackTable).apply_filter(event.value)
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         if event.input.id == "track-filter":
-            self._hide_filter()
+            try:
+                f = self.query_one("#track-filter", Input)
+                f.remove_class("visible")
+                self.query_one("#queue-table", TrackTable).focus()
+            except Exception:
+                pass
 
     def on_key(self, event: object) -> None:
         from textual.events import Key
@@ -473,8 +311,8 @@ class QueuePage(Widget):
                 if f.has_class("visible"):
                     event.stop()
                     event.prevent_default()
-                    self._filter_text = ""
-                    self._refresh_queue()
-                    self._hide_filter()
+                    self.query_one("#queue-table", TrackTable).clear_filter()
+                    f.remove_class("visible")
+                    self.query_one("#queue-table", TrackTable).focus()
             except Exception:
                 pass

--- a/src/ytm_player/ui/pages/recently_played.py
+++ b/src/ytm_player/ui/pages/recently_played.py
@@ -4,18 +4,20 @@ from __future__ import annotations
 
 import logging
 import sqlite3
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 from textual.app import ComposeResult
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
+from textual.events import Click
 from textual.reactive import reactive
 from textual.widget import Widget
-from textual.widgets import DataTable, Label, Static
-from textual.widgets.data_table import RowKey
+from textual.widgets import Input, Label, Static
 
 from ytm_player.config.keymap import Action
-from ytm_player.config.settings import get_settings
-from ytm_player.utils.formatting import format_duration
+from ytm_player.ui.widgets.track_table import TrackTable
+
+if TYPE_CHECKING:
+    from ytm_player.app._base import YTMHostBase
 
 logger = logging.getLogger(__name__)
 
@@ -43,16 +45,27 @@ class RecentlyPlayedPage(Widget):
         padding: 1 2;
         background: $surface;
     }
+    .recent-header-row {
+        height: auto;
+        width: 1fr;
+    }
+    .recent-header-row Label {
+        width: auto;
+    }
     .recent-header-title {
         text-style: bold;
         color: $primary;
     }
-    .recent-table {
-        height: 1fr;
-        width: 1fr;
+    #start-radio-btn {
+        width: auto;
+        min-width: 14;
+        height: 1;
+        margin: 0 0 0 1;
+        padding: 0 1;
+        color: $primary;
     }
-    .recent-table > .datatable--cursor {
-        background: $selected-item;
+    #start-radio-btn:hover {
+        background: $primary 30%;
     }
     .recent-footer {
         height: 1;
@@ -66,6 +79,13 @@ class RecentlyPlayedPage(Widget):
         content-align: center middle;
         color: $text-muted;
     }
+    .track-filter {
+        dock: bottom;
+        display: none;
+    }
+    .track-filter.visible {
+        display: block;
+    }
     """
 
     track_count: reactive[int] = reactive(0)
@@ -73,41 +93,24 @@ class RecentlyPlayedPage(Widget):
 
     def __init__(self, *, cursor_row: int | None = None, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self._row_keys: list[RowKey] = []
-        self._tracks: list[dict] = []
         self._restore_cursor_row = cursor_row
         # Set when ``_load_history`` catches an expected disk-side
-        # failure so ``_refresh_table`` can render the failure message
+        # failure so ``_display_tracks`` can render the failure message
         # instead of the genuine empty-state copy.
         self._load_failed = False
 
     def compose(self) -> ComposeResult:
-        yield Vertical(
-            Label("Recently Played", classes="recent-header-title"),
-            id="recent-header",
-            classes="recent-header",
-        )
+        with Vertical(id="recent-header", classes="recent-header"):
+            with Horizontal(classes="recent-header-row"):
+                yield Label("Recently Played", classes="recent-header-title")
+                yield Static("[▶ Start Radio]", id="start-radio-btn", markup=True)
         yield Label("Loading history...", id="recent-loading", classes="recent-loading")
-        yield DataTable(
-            cursor_type="row",
-            zebra_stripes=True,
-            id="recent-table",
-            classes="recent-table",
-        )
+        yield TrackTable(show_album=False, id="recent-table")
         yield Static("", id="recent-footer", classes="recent-footer")
+        yield Input(placeholder="/ Filter tracks...", id="track-filter", classes="track-filter")
 
     def on_mount(self) -> None:
-        table = self.query_one("#recent-table", DataTable)
-        ui = get_settings().ui
-
-        def w(v: int) -> int | None:
-            return v if v > 0 else None
-
-        table.add_column("#", width=w(ui.col_index), key="index")
-        table.add_column("Title", width=w(ui.col_title), key="title")
-        table.add_column("Artist", width=w(ui.col_artist), key="artist")
-        table.add_column("Duration", width=w(ui.col_duration), key="duration")
-        table.display = False
+        self.query_one("#recent-table", TrackTable).display = False
         self.run_worker(self._load_history(), group="recent-load")
 
     async def _load_history(self) -> None:
@@ -117,7 +120,7 @@ class RecentlyPlayedPage(Widget):
             return
 
         try:
-            self._tracks = await history.get_recently_played(limit=100)
+            tracks = await history.get_recently_played(limit=100)
             self._load_failed = False
         except (OSError, sqlite3.Error):
             # Local DB failure: file unreadable, disk full, DB locked,
@@ -126,18 +129,16 @@ class RecentlyPlayedPage(Widget):
             # must propagate so bugs surface in development per the
             # error-handling architecture in CLAUDE.md.
             logger.exception("Failed to load play history")
-            self._tracks = []
+            tracks = []
             self._load_failed = True
 
-        self._refresh_table()
+        self._display_tracks(tracks)
 
-    def _refresh_table(self) -> None:
-        table = self.query_one("#recent-table", DataTable)
+    def _display_tracks(self, tracks: list[dict]) -> None:
+        table = self.query_one("#recent-table", TrackTable)
         loading = self.query_one("#recent-loading", Label)
-        table.clear()
-        self._row_keys = []
 
-        if not self._tracks:
+        if not tracks:
             table.display = False
             if self._load_failed:
                 loading.update(_HISTORY_LOAD_FAILED_MSG)
@@ -148,18 +149,11 @@ class RecentlyPlayedPage(Widget):
 
         loading.display = False
         table.display = True
+        table.load_tracks(tracks)
 
-        for i, track in enumerate(self._tracks):
-            title = track.get("title", "Unknown")
-            artist = track.get("artist", "Unknown")
-            dur = track.get("duration_seconds", 0)
-            dur_str = format_duration(dur) if dur else "--:--"
-            row_key = table.add_row(str(i + 1), title, artist, dur_str, key=f"recent_{i}")
-            self._row_keys.append(row_key)
-
-        self.track_count = len(self._tracks)
+        self.track_count = len(tracks)
         footer = self.query_one("#recent-footer", Static)
-        footer.update(f"{len(self._tracks)} recently played tracks")
+        footer.update(f"{len(tracks)} recently played tracks")
 
         # Restore cursor position from navigation state.
         row = self._restore_cursor_row
@@ -171,7 +165,7 @@ class RecentlyPlayedPage(Widget):
         """Return state to preserve when navigating away."""
         state: dict[str, Any] = {}
         try:
-            table = self.query_one("#recent-table", DataTable)
+            table = self.query_one("#recent-table", TrackTable)
             if table.cursor_row is not None and table.cursor_row > 0:
                 state["cursor_row"] = table.cursor_row
         except Exception:
@@ -188,56 +182,94 @@ class RecentlyPlayedPage(Widget):
         if saved is not None and queue.shuffle_enabled != saved:
             queue.toggle_shuffle()
 
-    async def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+    async def on_track_table_track_selected(self, event: TrackTable.TrackSelected) -> None:
         event.stop()
-        idx = event.cursor_row
-        if 0 <= idx < len(self._tracks):
-            track = self._tracks[idx]
-            queue = self.app.queue  # type: ignore[attr-defined]
-            queue.add(track)
-            queue.jump_to_real(queue.length - 1)
-            self._apply_shuffle_pref(queue)
-            await self.app.play_track(track)  # type: ignore[attr-defined]
+        host = cast("YTMHostBase", self.app)
+        host.queue.add(event.track)
+        host.queue.jump_to_real(host.queue.length - 1)
+        self._apply_shuffle_pref(host.queue)
+        await host.play_track(event.track)
 
     async def handle_action(self, action: Action, count: int = 1) -> None:
-        table = self.query_one("#recent-table", DataTable)
+        table = self.query_one("#recent-table", TrackTable)
 
         match action:
-            case Action.MOVE_DOWN:
-                for _ in range(count):
-                    table.action_cursor_down()
-            case Action.MOVE_UP:
-                for _ in range(count):
-                    table.action_cursor_up()
-            case Action.PAGE_DOWN:
-                table.action_scroll_down()
-            case Action.PAGE_UP:
-                table.action_scroll_up()
-            case Action.GO_TOP:
-                if table.row_count > 0:
-                    table.move_cursor(row=0)
-            case Action.GO_BOTTOM:
-                if table.row_count > 0:
-                    table.move_cursor(row=table.row_count - 1)
-            case Action.JUMP_TO_CURRENT:
-                queue = self.app.queue  # type: ignore[attr-defined]
-                current = queue.current_track if queue else None
-                if current and current.get("video_id"):
-                    vid = current["video_id"]
-                    for i, t in enumerate(self._tracks):
-                        if t.get("video_id") == vid:
-                            table.move_cursor(row=i)
-                            break
-            case Action.SELECT:
-                if table.cursor_row is not None and 0 <= table.cursor_row < len(self._tracks):
-                    track = self._tracks[table.cursor_row]
-                    queue = self.app.queue  # type: ignore[attr-defined]
-                    queue.add(track)
-                    queue.jump_to_real(queue.length - 1)
-                    self._apply_shuffle_pref(queue)
-                    await self.app.play_track(track)  # type: ignore[attr-defined]
             case Action.ADD_TO_QUEUE:
-                if table.cursor_row is not None and 0 <= table.cursor_row < len(self._tracks):
-                    queue = self.app.queue  # type: ignore[attr-defined]
-                    queue.add(self._tracks[table.cursor_row])
+                track = table.selected_track
+                if track:
+                    host = cast("YTMHostBase", self.app)
+                    host.queue.add(track)
                     self.app.notify("Added to queue", timeout=2)
+            case Action.TRACK_ACTIONS:
+                track = table.selected_track
+                if track:
+                    host = cast("YTMHostBase", self.app)
+                    host._open_actions_for_track(track)
+            case _:
+                await table.handle_action(action, count)
+
+    def on_click(self, event: Click) -> None:
+        if event.widget is not None and event.widget.id == "start-radio-btn":
+            event.stop()
+            self.run_worker(self._start_radio(), name="start_radio", exclusive=True)
+
+    async def _start_radio(self) -> None:
+        import random
+
+        table = self.query_one("#recent-table", TrackTable)
+        tracks = table.tracks
+        if not tracks:
+            return
+        seeds = random.sample(tracks, min(5, len(tracks)))
+        seed_list = "\n".join(f"  • {s.get('title', 'Unknown')}" for s in seeds)
+        host = cast("YTMHostBase", self.app)
+        await host._fetch_and_play_radio(seeds, label=f"Radio: Recently Played\n{seed_list}")
+
+    def on_track_table_filter_requested(self, event: TrackTable.FilterRequested) -> None:
+        event.stop()
+        try:
+            f = self.query_one("#track-filter", Input)
+            f.value = ""
+            f.add_class("visible")
+            f.focus()
+        except Exception:
+            pass
+
+    def on_track_table_filter_closed(self, event: TrackTable.FilterClosed) -> None:
+        event.stop()
+        try:
+            f = self.query_one("#track-filter", Input)
+            f.remove_class("visible")
+            self.query_one("#recent-table", TrackTable).focus()
+        except Exception:
+            pass
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id == "track-filter":
+            self.query_one("#recent-table", TrackTable).apply_filter(event.value)
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id == "track-filter":
+            try:
+                f = self.query_one("#track-filter", Input)
+                f.remove_class("visible")
+                self.query_one("#recent-table", TrackTable).focus()
+            except Exception:
+                pass
+
+    def on_key(self, event: object) -> None:
+        from textual.events import Key
+
+        if not isinstance(event, Key):
+            return
+        if event.key == "escape":
+            try:
+                f = self.query_one("#track-filter", Input)
+                if f.has_class("visible"):
+                    event.stop()
+                    event.prevent_default()
+                    self.query_one("#recent-table", TrackTable).clear_filter()
+                    f.remove_class("visible")
+                    self.query_one("#recent-table", TrackTable).focus()
+            except Exception:
+                pass

--- a/src/ytm_player/utils/formatting.py
+++ b/src/ytm_player/utils/formatting.py
@@ -73,22 +73,27 @@ def extract_artist(track: dict) -> str:
 
 
 def extract_duration(track: dict) -> int:
-    """Extract duration in seconds from various track dict formats."""
+    """Extract duration in seconds from various track dict formats.
+
+    Checks ``duration_seconds``, ``duration``, and ``length``
+    (ytmusicapi's get_watch_playlist uses ``length`` for "M:SS" strings).
+    """
     dur = track.get("duration_seconds")
     if dur is not None:
         return int(dur)
-    dur = track.get("duration")
-    if isinstance(dur, int):
-        return dur
-    if isinstance(dur, str) and ":" in dur:
-        parts = dur.split(":")
-        try:
-            if len(parts) == 2:
-                return int(parts[0]) * 60 + int(parts[1])
-            if len(parts) == 3:
-                return int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
-        except ValueError:
-            pass
+    for key in ("duration", "length"):
+        dur = track.get(key)
+        if isinstance(dur, int):
+            return dur
+        if isinstance(dur, str) and ":" in dur:
+            parts = dur.split(":")
+            try:
+                if len(parts) == 2:
+                    return int(parts[0]) * 60 + int(parts[1])
+                if len(parts) == 3:
+                    return int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
+            except ValueError:
+                pass
     return 0
 
 
@@ -111,10 +116,9 @@ def normalize_tracks(raw_tracks: list[dict]) -> list[dict]:
         album_info = t.get("album")
         album = album_info.get("name", "") if isinstance(album_info, dict) else (album_info or "")
         album_id = album_info.get("id") if isinstance(album_info, dict) else t.get("album_id")
-        raw_dur = (
-            t.get("duration_seconds")
-            if t.get("duration_seconds") is not None
-            else t.get("duration")
+        raw_dur = next(
+            (t[k] for k in ("duration_seconds", "duration", "length") if t.get(k) is not None),
+            None,
         )
         duration = extract_duration(t) if raw_dur is not None else None
         thumbnail = None

--- a/tests/test_integration/test_page_failure_states.py
+++ b/tests/test_integration/test_page_failure_states.py
@@ -93,8 +93,8 @@ async def test_recently_played_shows_error_fallback_when_history_raises_oserror(
 
     await page._load_history()
 
-    # Tracks must be empty — the page falls back cleanly.
-    assert page._tracks == []
+    # Table must not have received any tracks — the page falls back cleanly.
+    widgets["#recent-table"].load_tracks.assert_not_called()
 
     # Loading label received the failure message and stays visible
     # so the user can read it.
@@ -127,7 +127,7 @@ async def test_recently_played_shows_error_fallback_when_history_raises_sqlite_e
 
     await page._load_history()
 
-    assert page._tracks == []
+    widgets["#recent-table"].load_tracks.assert_not_called()
     update_calls = [c.args[0] for c in widgets["#recent-loading"].update.call_args_list]
     assert any("Couldn't load history" in msg for msg in update_calls)
 

--- a/tests/test_utils/test_formatting.py
+++ b/tests/test_utils/test_formatting.py
@@ -194,6 +194,19 @@ class TestExtractDuration:
     def test_duration_seconds_zero(self):
         assert extract_duration({"duration_seconds": 0}) == 0
 
+    def test_length_string_mm_ss(self):
+        """get_watch_playlist returns duration as 'length' key."""
+        assert extract_duration({"length": "3:07"}) == 187
+
+    def test_length_string_hh_mm_ss(self):
+        assert extract_duration({"length": "1:00:00"}) == 3600
+
+    def test_duration_seconds_takes_priority_over_length(self):
+        assert extract_duration({"duration_seconds": 100, "length": "5:00"}) == 100
+
+    def test_duration_takes_priority_over_length(self):
+        assert extract_duration({"duration": 200, "length": "5:00"}) == 200
+
 
 # ── normalize_tracks ─────────────────────────────────────────────────
 
@@ -257,6 +270,11 @@ class TestNormalizeTracks:
     def test_duration_seconds_zero(self):
         result = normalize_tracks([{"videoId": "x", "duration_seconds": 0}])
         assert result[0]["duration"] == 0
+
+    def test_length_key_from_watch_playlist(self):
+        """get_watch_playlist returns 'length' instead of 'duration'."""
+        result = normalize_tracks([{"videoId": "x", "title": "Radio Track", "length": "3:07"}])
+        assert result[0]["duration"] == 187
 
     def test_album_as_string(self):
         result = normalize_tracks([{"videoId": "x", "album": "My Album"}])


### PR DESCRIPTION
## Summary

- Replaces raw DataTable with TrackTable in Queue, Liked Songs, and Recently Played pages — gains right-click context menus, play indicators, column resize, filtering, and sorting
- Adds radio button and shuffle-lock integration to Liked Songs and Recently Played headers
- Fixes duration handling: `extract_duration()` now checks the `length` key from `get_watch_playlist`, `log_play()` uses `extract_duration()` instead of raw `duration_seconds`, and Recently Played auto-backfills stale 0-duration rows on page load