### PR TITLE
feat: add configurable default theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+## [Unreleased]
+
+**New features**
+
+- **Configurable default theme** — set `theme` under `[ui]` in `config.toml` to control which Textual theme loads on startup (default `ytm-dark`). Changing theme via `Ctrl+P` → `Theme` updates the current session only; the startup default is no longer overwritten by session state. To persist the active theme as the new default, use `Ctrl+P` → `Theme: Set Current as Default`.
+- **`Theme: Set Current as Default` command palette action** — saves the currently active theme to `config.toml` so it becomes the startup default. Includes rollback on save failure (e.g. read-only filesystem) with an error toast.
+
+**Changed**
+
+- **Theme persistence model** — `config.toml` is now the authoritative source for the startup theme; `session.json` stores runtime state only and no longer restores the theme on launch. This separates user-authored configuration from app-managed session state.
+- **Command palette provider architecture** — app-specific commands moved from `get_system_commands()` to a dedicated `YTMCommandProvider` registered in `App.COMMANDS`. Isolates command definitions in `src/ytm_player/app/_commands.py` and keeps `_app.py` focused on app logic.
+
+**Infrastructure**
+
+- **Settings save Windows fallback** — `Settings.save()` now falls back to a direct `path.write_text()` when `os.replace()` raises `PermissionError` (e.g. when `config.toml` is held open by an external editor on Windows).
+
 ### v1.9.1 (2026-04-30)
 
 This is the third and final wave of major updates in a rapid release cycle — quieter cadence ahead.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,6 +64,7 @@ js_runtimes = ""             # Optional: bun, bun:/path/to/bun, node, quickjs, e
 
 ```toml
 [ui]
+theme = "ytm-dark"           # startup default Textual theme; runtime changes are saved in session.json
 album_art = true             # show colored half-block album art in playback bar
 progress_style = "block"     # block or line
 sidebar_width = 30
@@ -78,6 +79,8 @@ home_shelves = 3             # number of recommendation shelves on Browse → Fo
 show_selection_info = true   # show focused-item full name in the row above the playback bar
 sidebar_overflow = "truncate"  # "truncate" (1-row + ellipsis) or "wrap" (multi-line names)
 ```
+
+`theme` is the startup default. Changing theme from Textual's command palette (`Ctrl+P` → `Theme`) updates the current session and is saved in `session.json`, not `config.toml`. To make the active theme the new default, run `Ctrl+P` → `Set Current Theme as Default`.
 
 Per-playlist Shuffle lock state (set via the `Shuffle lock` toggle in the
 Library page playlist header) is persisted separately to
@@ -128,7 +131,7 @@ backup_count = 5             # number of rotated logs to keep
 
 ## `theme.toml`
 
-Base colors (primary, background, etc.) come from the active Textual theme — switch themes with `Ctrl+P`. The `theme.toml` file overrides app-specific colors only:
+Base colors (primary, background, etc.) come from the active Textual theme. Choose the startup default with `[ui] theme`, switch the current session with `Ctrl+P` → `Theme`, and use `theme.toml` for app-specific color overrides:
 
 ```toml
 [colors]

--- a/src/ytm_player/app/_app.py
+++ b/src/ytm_player/app/_app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import sys
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -14,8 +15,9 @@ else:
     # Python 3.10 backport via PyPI
     import tomli as tomllib  # pyright: ignore[reportMissingImports]
 
-from textual.app import App, ComposeResult
+from textual.app import App, ComposeResult, SystemCommand
 from textual.containers import Container, Horizontal, Vertical
+from textual.screen import Screen
 
 from ytm_player.app._ipc import IPCMixin
 from ytm_player.app._keys import KeyHandlingMixin
@@ -184,15 +186,15 @@ class YTMPlayerApp(
     def __init__(self) -> None:
         super().__init__()
 
-        # Register custom YTM theme and set as default.
+        # Register custom YTM theme and set the configured default.
         from ytm_player.ui.theme import YTM_DARK
 
         self.register_theme(YTM_DARK)
-        self.theme = "ytm-dark"
 
         # Configuration.
         self.settings: Settings = get_settings()
         self.keymap: KeyMap = get_keymap()
+        self.theme = self.settings.ui.theme or "ytm-dark"
         self.theme_colors: ThemeColors = get_theme()
 
         # Services (initialized in on_mount).
@@ -369,6 +371,33 @@ class YTMPlayerApp(
             self.theme_colors = tc
         except Exception:
             pass
+
+    def get_system_commands(self, screen: Screen) -> Iterable[SystemCommand]:
+        yield from super().get_system_commands(screen)
+        yield SystemCommand(
+            "Set Current Theme as Default",
+            "Save the active theme to config.toml",
+            self.action_set_current_theme_as_default,
+        )
+
+    def action_set_current_theme_as_default(self) -> None:
+        """Persist the active runtime theme as the config.toml default."""
+        previous_theme = self.settings.ui.theme
+        current_theme = str(self.theme)
+        self.settings.ui.theme = current_theme
+        try:
+            self.settings.save()
+        except OSError:
+            self.settings.ui.theme = previous_theme
+            logger.exception("Failed to save default theme to config.toml")
+            self.notify(
+                "Could not save default theme to config.toml",
+                severity="error",
+                timeout=5,
+            )
+            return
+
+        self.notify(f"Saved {current_theme} as default theme", timeout=3)
 
     # ── Crash diagnostics ────────────────────────────────────────────
 

--- a/src/ytm_player/app/_app.py
+++ b/src/ytm_player/app/_app.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import sys
-from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -15,9 +14,8 @@ else:
     # Python 3.10 backport via PyPI
     import tomli as tomllib  # pyright: ignore[reportMissingImports]
 
-from textual.app import App, ComposeResult, SystemCommand
+from textual.app import App, ComposeResult
 from textual.containers import Container, Horizontal, Vertical
-from textual.screen import Screen
 
 from ytm_player.app._ipc import IPCMixin
 from ytm_player.app._keys import KeyHandlingMixin
@@ -90,6 +88,13 @@ def _read_theme_toml_cached() -> dict:
         return _theme_toml_cache
     except Exception:
         return {}
+
+
+def _get_ytm_commands_provider():
+    """Lazy-load the custom YTM command provider to avoid circular imports."""
+    from ytm_player.app._commands import YTMCommandProvider
+
+    return YTMCommandProvider
 
 
 # ── Main Application ────────────────────────────────────────────────
@@ -182,6 +187,9 @@ class YTMPlayerApp(
 
     # We handle all bindings ourselves through the KeyMap system.
     BINDINGS = []
+
+    # Register custom command palette providers alongside Textual's defaults.
+    COMMANDS = App.COMMANDS | {_get_ytm_commands_provider}
 
     def __init__(self) -> None:
         super().__init__()
@@ -371,14 +379,6 @@ class YTMPlayerApp(
             self.theme_colors = tc
         except Exception:
             pass
-
-    def get_system_commands(self, screen: Screen) -> Iterable[SystemCommand]:
-        yield from super().get_system_commands(screen)
-        yield SystemCommand(
-            "Set Current Theme as Default",
-            "Save the active theme to config.toml",
-            self.action_set_current_theme_as_default,
-        )
 
     def action_set_current_theme_as_default(self) -> None:
         """Persist the active runtime theme as the config.toml default."""

--- a/src/ytm_player/app/_commands.py
+++ b/src/ytm_player/app/_commands.py
@@ -1,0 +1,36 @@
+"""Custom command palette providers for ytm-player."""
+
+from __future__ import annotations
+
+from textual.command import DiscoveryHit, Hit, Provider
+
+
+class YTMCommandProvider(Provider):
+    """Custom command provider for ytm-player specific actions."""
+
+    async def discover(self) -> None:
+        """Yield discovery hits for ytm-player commands."""
+        yield DiscoveryHit(
+            "Theme: Set Current as Default",
+            self.app.action_set_current_theme_as_default,
+            help="Save the active theme to config.toml",
+        )
+
+    async def search(self, query: str) -> None:
+        """Fuzzy search ytm-player commands."""
+        matcher = self.matcher(query)
+        commands = [
+            (
+                "Theme: Set Current as Default",
+                self.app.action_set_current_theme_as_default,
+                "Save the active theme to config.toml",
+            ),
+        ]
+        for name, callback, help_text in commands:
+            if (match := matcher.match(name)) > 0:
+                yield Hit(
+                    match,
+                    matcher.highlight(name),
+                    callback,
+                    help=help_text,
+                )

--- a/src/ytm_player/app/_session.py
+++ b/src/ytm_player/app/_session.py
@@ -95,14 +95,6 @@ class SessionMixin(YTMHostBase):
         # files (or fresh installs) trigger the toast on first launch.
         self._first_run_hint_shown = bool(state.get("first_run_hint_shown", False))
 
-        # Restore Textual theme from last session.
-        saved_theme = state.get("theme")
-        if saved_theme and isinstance(saved_theme, str):
-            try:
-                self.theme = saved_theme
-            except Exception:
-                pass
-
         # Restore transliteration toggle state (session overrides config).
         if "transliteration_enabled" in state:
             try:

--- a/src/ytm_player/config/settings.py
+++ b/src/ytm_player/config/settings.py
@@ -68,6 +68,7 @@ class CacheSettings:
 
 @dataclass
 class UISettings:
+    theme: str = "ytm-dark"
     album_art: bool = True
     border_style: str = "rounded"
     progress_style: str = "block"
@@ -210,11 +211,16 @@ class Settings:
                 lines.append(f"{f_info.name} = {_format_toml_value(value)}")
             lines.append("")
 
+        content = "\n".join(lines)
         tmp_path = path.with_suffix(path.suffix + ".tmp")
         try:
-            tmp_path.write_text("\n".join(lines), encoding="utf-8")
+            tmp_path.write_text(content, encoding="utf-8")
             secure_chmod(tmp_path, SECURE_FILE_MODE)
-            os.replace(tmp_path, path)
+            try:
+                os.replace(tmp_path, path)
+            except PermissionError:
+                path.write_text(content, encoding="utf-8")
+                secure_chmod(path, SECURE_FILE_MODE)
         finally:
             # Clean up temp file if replace failed.
             if tmp_path.exists():

--- a/tests/test_app/test_theme_config_default.py
+++ b/tests/test_app/test_theme_config_default.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from ytm_player.app._app import YTMPlayerApp
+from ytm_player.config.settings import Settings
+
+
+def test_app_initializes_theme_from_ui_settings(monkeypatch):
+    settings = Settings()
+    settings.ui.theme = "textual-dark"
+
+    monkeypatch.setattr("ytm_player.app._app.get_settings", lambda: settings)
+    monkeypatch.setattr("ytm_player.app._app.get_keymap", MagicMock())
+    monkeypatch.setattr("ytm_player.app._app.get_theme", MagicMock())
+
+    app = YTMPlayerApp()
+
+    assert app.theme == "textual-dark"
+
+
+def test_set_current_theme_as_default_saves_config(monkeypatch):
+    settings = Settings()
+    settings.ui.theme = "ytm-dark"
+    settings.save = MagicMock()
+
+    monkeypatch.setattr("ytm_player.app._app.get_settings", lambda: settings)
+    monkeypatch.setattr("ytm_player.app._app.get_keymap", MagicMock())
+    monkeypatch.setattr("ytm_player.app._app.get_theme", MagicMock())
+
+    app = YTMPlayerApp()
+    app.theme = "textual-dark"
+    app.notify = MagicMock()
+
+    app.action_set_current_theme_as_default()
+
+    assert settings.ui.theme == "textual-dark"
+    settings.save.assert_called_once_with()
+    app.notify.assert_called_once()
+    args, kwargs = app.notify.call_args
+    message = args[0] if args else kwargs.get("message", "")
+    assert "textual-dark" in message
+    assert kwargs.get("severity") in (None, "information")
+
+
+def test_set_current_theme_as_default_rolls_back_on_save_failure(monkeypatch):
+    settings = Settings()
+    settings.ui.theme = "ytm-dark"
+    settings.save = MagicMock(side_effect=OSError("read-only filesystem"))
+
+    monkeypatch.setattr("ytm_player.app._app.get_settings", lambda: settings)
+    monkeypatch.setattr("ytm_player.app._app.get_keymap", MagicMock())
+    monkeypatch.setattr("ytm_player.app._app.get_theme", MagicMock())
+
+    app = YTMPlayerApp()
+    app.theme = "textual-dark"
+    app.notify = MagicMock()
+
+    app.action_set_current_theme_as_default()
+
+    assert settings.ui.theme == "ytm-dark"
+    settings.save.assert_called_once_with()
+    app.notify.assert_called_once()
+    _, kwargs = app.notify.call_args
+    assert kwargs.get("severity") == "error"
+
+
+def test_command_palette_exposes_set_default_theme(monkeypatch):
+    settings = Settings()
+
+    monkeypatch.setattr("ytm_player.app._app.get_settings", lambda: settings)
+    monkeypatch.setattr("ytm_player.app._app.get_keymap", MagicMock())
+    monkeypatch.setattr("ytm_player.app._app.get_theme", MagicMock())
+
+    app = YTMPlayerApp()
+    screen = MagicMock()
+    screen.query.return_value = []
+    screen.maximized = None
+    screen.focused = None
+    commands = list(app.get_system_commands(screen))
+
+    assert any(command.title == "Set Current Theme as Default" for command in commands)

--- a/tests/test_app/test_theme_config_default.py
+++ b/tests/test_app/test_theme_config_default.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from ytm_player.app._app import YTMPlayerApp
+from ytm_player.app._commands import YTMCommandProvider
 from ytm_player.config.settings import Settings
 
 
@@ -65,18 +68,56 @@ def test_set_current_theme_as_default_rolls_back_on_save_failure(monkeypatch):
     assert kwargs.get("severity") == "error"
 
 
-def test_command_palette_exposes_set_default_theme(monkeypatch):
-    settings = Settings()
-
-    monkeypatch.setattr("ytm_player.app._app.get_settings", lambda: settings)
-    monkeypatch.setattr("ytm_player.app._app.get_keymap", MagicMock())
-    monkeypatch.setattr("ytm_player.app._app.get_theme", MagicMock())
-
-    app = YTMPlayerApp()
+@pytest.mark.asyncio
+async def test_ytm_command_provider_discover_yields_theme_command():
+    app = MagicMock()
     screen = MagicMock()
-    screen.query.return_value = []
-    screen.maximized = None
-    screen.focused = None
-    commands = list(app.get_system_commands(screen))
+    screen.app = app
 
-    assert any(command.title == "Set Current Theme as Default" for command in commands)
+    provider = YTMCommandProvider(screen)
+    hits = [hit async for hit in provider.discover()]
+
+    assert len(hits) == 1
+    hit = hits[0]
+    assert "Theme: Set Current as Default" in str(hit.display)
+    assert hit.command is app.action_set_current_theme_as_default
+    assert "Save the active theme to config.toml" in str(hit.help)
+
+
+@pytest.mark.asyncio
+async def test_ytm_command_provider_search_matches_theme_command():
+    app = MagicMock()
+    screen = MagicMock()
+    screen.app = app
+
+    provider = YTMCommandProvider(screen)
+    hits = [hit async for hit in provider.search("theme default")]
+
+    assert len(hits) == 1
+    hit = hits[0]
+    assert hit.score > 0
+    assert hit.command is app.action_set_current_theme_as_default
+
+
+@pytest.mark.asyncio
+async def test_ytm_command_provider_search_no_match_for_irrelevant_query():
+    app = MagicMock()
+    screen = MagicMock()
+    screen.app = app
+
+    provider = YTMCommandProvider(screen)
+    hits = [hit async for hit in provider.search("zzzzzzzzz")]
+
+    assert len(hits) == 0
+
+
+def test_app_commands_includes_ytm_provider():
+    from textual.app import App
+    from textual.system_commands import SystemCommandsProvider
+
+    from ytm_player.app._app import _get_ytm_commands_provider
+
+    assert SystemCommandsProvider in {cls() for cls in App.COMMANDS}
+    provider_cls = _get_ytm_commands_provider()
+    assert provider_cls is YTMCommandProvider
+    assert _get_ytm_commands_provider in YTMPlayerApp.COMMANDS

--- a/tests/test_config/test_settings.py
+++ b/tests/test_config/test_settings.py
@@ -23,9 +23,28 @@ class TestDefaultValues:
         assert s.search.default_mode == "music"
         assert s.cache.enabled is True
         assert s.cache.max_size_mb == 1024
+        assert s.ui.theme == "ytm-dark"
         assert s.ui.album_art is True
         assert s.notifications.enabled is True
         assert s.mpris.enabled is True
+
+
+def test_ui_settings_theme_default():
+    """theme defaults to the bundled ytm-dark Textual theme."""
+    from ytm_player.config.settings import UISettings
+
+    ui = UISettings()
+    assert ui.theme == "ytm-dark"
+
+
+def test_settings_load_respects_ui_theme(tmp_config_dir):
+    """theme in [ui] is honoured as the declarative default."""
+    config_file = tmp_config_dir / "config.toml"
+    config_file.write_text('[ui]\ntheme = "catppuccin-mocha"\n', encoding="utf-8")
+
+    s = Settings.load(config_file)
+
+    assert s.ui.theme == "catppuccin-mocha"
 
 
 def test_ui_settings_show_selection_info_default():
@@ -68,12 +87,14 @@ class TestSaveLoadRoundTrip:
         original.playback.default_volume = 50
         original.general.startup_page = "search"
         original.cache.max_size_mb = 2048
+        original.ui.theme = "textual-dark"
         original.save(path)
 
         loaded = Settings.load(path)
         assert loaded.playback.default_volume == 50
         assert loaded.general.startup_page == "search"
         assert loaded.cache.max_size_mb == 2048
+        assert loaded.ui.theme == "textual-dark"
         # Other defaults preserved.
         assert loaded.playback.audio_quality == "high"
         assert loaded.ui.album_art is True
@@ -145,3 +166,24 @@ class TestAtomicWrites:
         assert str(config_path) in targets, (
             f"expected os.replace into {config_path}, got replace calls: {replace_calls}"
         )
+
+    def test_save_falls_back_to_direct_write_when_replace_is_denied(self, tmp_path, monkeypatch):
+        """Windows may deny os.replace when config.toml is held by another process."""
+        import os
+
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("stale", encoding="utf-8")
+
+        def denied_replace(_src, _dst):
+            raise PermissionError("access denied")
+
+        monkeypatch.setattr(os, "replace", denied_replace)
+
+        s = Settings()
+        s.ui.theme = "textual-dark"
+        s.save(config_path)
+
+        with open(config_path, "rb") as f:
+            data = tomllib.load(f)
+        assert data["ui"]["theme"] == "textual-dark"
+        assert not config_path.with_suffix(config_path.suffix + ".tmp").exists()

--- a/tests/test_integration/test_session_round_trip.py
+++ b/tests/test_integration/test_session_round_trip.py
@@ -64,6 +64,7 @@ def _build_session_host():
     h.settings = MagicMock()
     h.settings.playback.default_volume = 80
     h.settings.playback.resume_on_launch = True
+    h.settings.ui.theme = "catppuccin-mocha"
 
     # Misc state the mixin pokes at on load + save.
     h.query_one = MagicMock()
@@ -118,14 +119,15 @@ async def test_valid_round_trip_persists_and_restores(tmp_path, monkeypatch):
 
     # ---- Restore side: a fresh host loads the file we just wrote. -----------
     loader = _build_session_host()
+    loader.theme = loader.settings.ui.theme
     await loader._restore_session_state()
 
     loader.player.set_volume.assert_awaited_once_with(42)
     loader.queue.set_repeat.assert_called_once_with(RepeatMode.ALL)
     # shuffle was False -> toggle_shuffle must NOT have been called.
     loader.queue.toggle_shuffle.assert_not_called()
-    # theme string is propagated onto the host.
-    assert loader.theme == "textual-dark"
+    # The configured default theme wins on startup; session theme is only runtime state.
+    assert loader.theme == "catppuccin-mocha"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- Adds `[ui] theme` as the declarative startup default in `config.toml`.
- Keeps normal command-palette theme changes as runtime-only session state, so `config.toml` wins again on restart unless the user explicitly saves a new default.
- Adds `Set Current Theme as Default` to the Textual command palette and handles Windows `PermissionError` when `config.toml` is open in an editor.

## Context
- Follow-up to the hybrid approach discussed in #34.
- Related to #33.

## Test Plan
- `ruff format src/ tests/`
- `ruff check src/ tests/`
- `pytest`

## Notes
This preserves the `config.toml` user-authored / `session.json` app-managed split: runtime theme switches do not silently rewrite config, and the config default controls startup.