### PR TITLE
fix: include packaging in Nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,7 @@
             aiosqlite
             click
             pillow         # album art (moved from optional to core in v1.3.1)
+            packaging
           ];
 
           optional-dependencies = with python.pkgs; {
@@ -119,6 +120,7 @@
           pythonImportsCheck = [
             "ytm_player"
             "ytm_player.cli"
+            "ytm_player.services.update_check"
           ];
 
           meta = {


### PR DESCRIPTION
Fixes #95.

src/ytm_player/services/update_check.py imports packaging.version, but the Nix flake build did not include packaging in the Python dependencies. Because the module is loaded by a background update-check worker, the existing import check did not catch the missing package.

This PR:
- adds packaging to the flake's dependencies
- adds ytm_player.services.update_check to pythonImportsCheck so this path is covered by the Nix build