### PR TITLE
ci(aur): derive pkgver from the release tag name, drop release-commit fetch (CodeQL #6)

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -88,18 +88,24 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Copy PKGBUILD and regenerate .SRCINFO
+        # PKGVER enters via env, never ${{ }} inline in the script — inline
+        # expression splicing is the CodeQL actions/code-injection sink.
+        env:
+          PKGVER: ${{ steps.version.outputs.pkgver }}
         run: |
           cp aur/PKGBUILD /tmp/aur-repo/PKGBUILD
           # Force the real version into the pushed PKGBUILD — the pkgver= in
           # aur/PKGBUILD is a placeholder and may be stale (the v2.0.0 lesson).
           # regenerate_srcinfo.py emits this literal line into .SRCINFO.
-          sed -i "s/^pkgver=.*/pkgver=${{ steps.version.outputs.pkgver }}/" /tmp/aur-repo/PKGBUILD
+          sed -i "s/^pkgver=.*/pkgver=$PKGVER/" /tmp/aur-repo/PKGBUILD
           python3 scripts/regenerate_srcinfo.py /tmp/aur-repo/PKGBUILD /tmp/aur-repo/.SRCINFO
           echo "--- Diff vs previous AUR state ---"
           cd /tmp/aur-repo
           git diff --stat HEAD || true
 
       - name: Commit and push to AUR
+        env:
+          PKGVER: ${{ steps.version.outputs.pkgver }}
         run: |
           cd /tmp/aur-repo
           if git diff --quiet HEAD; then
@@ -107,6 +113,6 @@ jobs:
             exit 0
           fi
           git add PKGBUILD .SRCINFO
-          git commit -m "Update to v${{ steps.version.outputs.pkgver }}"
+          git commit -m "Update to v$PKGVER"
           git push origin master
-          echo "AUR push complete for v${{ steps.version.outputs.pkgver }}"
+          echo "AUR push complete for v$PKGVER"

--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -26,41 +26,37 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
-        # No ref: on workflow_run this checks out the default branch, so the
-        # only code this privileged job executes (scripts/regenerate_srcinfo.py
-        # below) comes from trusted master — never from the triggering commit
-        # (CodeQL actions/untrusted-checkout). The release commit's files are
-        # extracted as plain data in the next step.
+        # No ref: always the default branch. Nothing from the triggering
+        # commit is fetched, checked out, or executed in this privileged job
+        # (CodeQL actions/untrusted-checkout — alerts #5 and #6).
         uses: actions/checkout@v7
 
-      - name: Extract release files from the triggering commit
-        # The version + PKGBUILD must come from the exact commit the Publish
-        # run built — the same one its tag guard verified — but only as DATA
-        # via `git show`; nothing from that commit is checked out or executed.
-        env:
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-        run: |
-          if [ -n "$HEAD_SHA" ]; then
-            git fetch --depth=1 origin "$HEAD_SHA"
-            git show "$HEAD_SHA:src/ytm_player/__init__.py" > /tmp/release_init.py
-            git show "$HEAD_SHA:aur/PKGBUILD" > /tmp/release_pkgbuild
-          else
-            # workflow_dispatch: no upstream run — use the checked-out files.
-            cp src/ytm_player/__init__.py /tmp/release_init.py
-            cp aur/PKGBUILD /tmp/release_pkgbuild
-          fi
-
-      # The version comes from __version__ — the same source of truth the
-      # Publish workflow's tag guard checks. The pkgver= line in aur/PKGBUILD
-      # is only a placeholder; it is overwritten below so a forgotten manual
-      # bump can never push a stale version to AUR again (the v2.0.0 lesson).
-      - name: Read version from package
+      # The version comes from the triggering Publish run's tag name
+      # (workflow_run.head_branch is the pushed tag for tag-triggered runs).
+      # publish.yml's tag guard refuses to publish unless that tag matches
+      # __version__, so the tag IS the verified release version — nothing
+      # needs to be read from the release commit at all. The pkgver= line in
+      # aur/PKGBUILD is only a placeholder; it is overwritten below so a
+      # forgotten manual bump can never push a stale version to AUR again
+      # (the v2.0.0 lesson). workflow_dispatch falls back to __version__
+      # from the checkout.
+      - name: Determine release version
         id: version
+        env:
+          TAG_NAME: ${{ github.event.workflow_run.head_branch }}
         run: |
-          PKGVER=$(grep -oP '^__version__\s*=\s*"\K[^"]+' /tmp/release_init.py || true)
-          if [ -z "$PKGVER" ]; then
-            echo "::error::Could not read __version__ from the release commit's src/ytm_player/__init__.py"
-            exit 1
+          if [ -n "$TAG_NAME" ]; then
+            if ! printf '%s\n' "$TAG_NAME" | grep -qE '^v[0-9][0-9A-Za-z.]*$'; then
+              echo "::error::Triggering ref '$TAG_NAME' is not a version tag; refusing to publish."
+              exit 1
+            fi
+            PKGVER="${TAG_NAME#v}"
+          else
+            PKGVER=$(grep -oP '^__version__\s*=\s*"\K[^"]+' src/ytm_player/__init__.py || true)
+            if [ -z "$PKGVER" ]; then
+              echo "::error::Could not read __version__ from src/ytm_player/__init__.py"
+              exit 1
+            fi
           fi
           echo "pkgver=$PKGVER" >> "$GITHUB_OUTPUT"
           echo "Detected version: $PKGVER"
@@ -93,7 +89,7 @@ jobs:
 
       - name: Copy PKGBUILD and regenerate .SRCINFO
         run: |
-          cp /tmp/release_pkgbuild /tmp/aur-repo/PKGBUILD
+          cp aur/PKGBUILD /tmp/aur-repo/PKGBUILD
           # Force the real version into the pushed PKGBUILD — the pkgver= in
           # aur/PKGBUILD is a placeholder and may be stale (the v2.0.0 lesson).
           # regenerate_srcinfo.py emits this literal line into .SRCINFO.


### PR DESCRIPTION
Closes code scanning alert #6 (actions/untrusted-checkout, raised on the workflow_run job fetching the triggering commit).

The privileged AUR job no longer touches the triggering commit at all: pkgver derives from the tag name in the event payload (validated ^v[0-9][0-9A-Za-z.]*$, stripped of the leading v), with fallback to __version__ from the default-branch checkout for workflow_dispatch. PKGBUILD comes from the default-branch checkout — correct for the -git package, which builds master HEAD anyway.

Tested against the committed code: 7 version-derivation cases (real tags, rc tag, garbage refs, injection-shaped string, dispatch fallback) plus the full PKGBUILD→.SRCINFO regeneration path — all pass. Codex review: APPROVE.

Merge gate: CodeQL PR analysis must come back with no new findings.