### PR TITLE
fix(macos): stop the phantom bouncing Python Dock icon

### DIFF
--- a/src/ytm_player/services/macos_app.py
+++ b/src/ytm_player/services/macos_app.py
@@ -1,0 +1,47 @@
+"""
+Purpose: Keep the ytm-player process out of the macOS Dock and app switcher.
+Interface: hide_dock_icon().
+Invariants: No-op off macOS and when AppKit is unavailable; never raises.
+Decisions: Use Accessory rather than Prohibited so the process stays a real,
+activatable app and can still serve MPRemoteCommandCenter / Now Playing.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+try:
+    _APPKIT: Any = importlib.import_module("AppKit")
+
+    _APPKIT_AVAILABLE = True
+except ImportError:
+    _APPKIT = None
+    _APPKIT_AVAILABLE = False
+
+# NSApplicationActivationPolicyAccessory: the process runs without a Dock tile
+# and without an app-switcher entry, but stays activatable — unlike Prohibited,
+# which would also make it ineligible as a Now Playing source.
+_ACTIVATION_POLICY_ACCESSORY = 1
+
+
+def hide_dock_icon() -> bool:
+    """Demote this process to an accessory app, so macOS gives it no Dock tile.
+
+    Returns True if the activation policy was applied, False if it wasn't
+    needed (non-macOS) or couldn't be (AppKit missing, or the call failed).
+    """
+    if sys.platform != "darwin" or not _APPKIT_AVAILABLE:
+        return False
+    try:
+        app = _APPKIT.NSApplication.sharedApplication()
+        app.setActivationPolicy_(_ACTIVATION_POLICY_ACCESSORY)
+    except Exception:
+        logger.debug("Could not set macOS activation policy", exc_info=True)
+        return False
+    logger.info("macOS activation policy set to accessory (no Dock icon)")
+    return True

--- a/src/ytm_player/services/player.py
+++ b/src/ytm_player/services/player.py
@@ -14,6 +14,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from ytm_player.services.macos_app import hide_dock_icon
 from ytm_player.utils.compat import StrEnum, auto
 
 if sys.platform == "win32":
@@ -256,6 +257,13 @@ class Player:
             log_handler=_on_mpv_log,
             loglevel="warn",
         )
+
+        # Creating the mpv handle initialises Cocoa in-process, which promotes
+        # this process to a foreground GUI app: macOS then shows a generic
+        # "Python" Dock tile that bounces indefinitely, because nothing ever
+        # signals that app launch finished.  Demote it now that mpv is up —
+        # doing this earlier is useless, since libmpv re-promotes it.
+        hide_dock_icon()
 
         # Enable gapless playback if configured.
         if settings.playback.gapless:

--- a/tests/test_services/test_macos_app.py
+++ b/tests/test_services/test_macos_app.py
@@ -1,0 +1,45 @@
+"""Tests for ytm_player.services.macos_app."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from ytm_player.services import macos_app
+from ytm_player.services.macos_app import hide_dock_icon
+
+
+class TestHideDockIcon:
+    def test_noop_off_macos(self) -> None:
+        with patch.object(macos_app.sys, "platform", "linux"):
+            assert hide_dock_icon() is False
+
+    def test_noop_when_appkit_unavailable(self) -> None:
+        with (
+            patch.object(macos_app.sys, "platform", "darwin"),
+            patch.object(macos_app, "_APPKIT_AVAILABLE", False),
+        ):
+            assert hide_dock_icon() is False
+
+    def test_sets_accessory_policy_on_macos(self) -> None:
+        app = MagicMock()
+        appkit = MagicMock()
+        appkit.NSApplication.sharedApplication.return_value = app
+        with (
+            patch.object(macos_app.sys, "platform", "darwin"),
+            patch.object(macos_app, "_APPKIT_AVAILABLE", True),
+            patch.object(macos_app, "_APPKIT", appkit),
+        ):
+            assert hide_dock_icon() is True
+        # Accessory (1), not Prohibited (2): Prohibited would also make the
+        # process ineligible as a Now Playing source.
+        app.setActivationPolicy_.assert_called_once_with(1)
+
+    def test_swallows_appkit_errors(self) -> None:
+        appkit = MagicMock()
+        appkit.NSApplication.sharedApplication.side_effect = RuntimeError("no window server")
+        with (
+            patch.object(macos_app.sys, "platform", "darwin"),
+            patch.object(macos_app, "_APPKIT_AVAILABLE", True),
+            patch.object(macos_app, "_APPKIT", appkit),
+        ):
+            assert hide_dock_icon() is False


### PR DESCRIPTION
## Summary

On macOS, running `ytm` puts a generic **"Python" icon in the Dock that bounces indefinitely**. Audio and the TUI work fine, but the process looks permanently stuck, and force-quitting the tile kills playback (libmpv is in-process, so there's no separate `mpv` to survive).

Cause: creating the mpv handle in `Player._init_mpv()` initialises Cocoa inside our own process, which promotes it to a foreground GUI app. macOS gives that a Dock tile — generic Python icon, since the interpreter isn't an app bundle — and it bounces forever because nothing ever signals that app launch finished.

Fix: a small `services/macos_app.py` with `hide_dock_icon()`, called right after the mpv handle is created. Two details that took some narrowing down:

- **Accessory (1), not Prohibited (2).** Both remove the Dock tile, but Prohibited means "cannot be activated", which would also make ytm ineligible as a Now Playing source. Accessory keeps `MPRemoteCommandCenter` and the media keys working — I verified that registering the command center *after* setting Accessory does not re-promote the process.
- **Ordering matters.** The call must come after mpv init; setting the policy earlier is useless, because libmpv's Cocoa init re-promotes the process.

Things I tried that don't work, in case they come up in review:

| Attempt | Result |
|---|---|
| `[mpris] enabled = false` | Tile persists — unrelated to the Now Playing / event-tap path |
| mpv's `--macos-app-activation-policy=prohibited` | Accepted (property reads back `prohibited`), still registered |
| `video=False` | Already set; audio-only still brings up Cocoa |
| Non-framework interpreter | Reproduces under a uv-managed CPython, so not specific to Homebrew's `Python.app` |

The module follows `macos_media.py`'s conventions: `importlib` for the optional pyobjc framework, degrade to a no-op rather than raise, and no-op off macOS.

## Testing

Measured with `lsappinfo list`, which reports a pid's `type=` — `Foreground` means it has a Dock tile, `UIElement` means it doesn't:

| | `type=` |
|---|---|
| before | `Foreground` |
| after | `UIElement` |

Confirmed by calling the real `Player()._init_mpv()` rather than a reimplementation, on macOS 15 (Apple Silicon), Python 3.14, mpv 0.41.0 / libmpv from Homebrew.

- [x] Ran `ruff format src/ tests/` — 176 files unchanged
- [x] Ran `ruff check src/ tests/` — all checks passed
- [x] Ran `pytest tests/` — 1394 passed, 13 skipped
- [x] `pyright` on the changed files — 0 errors
- [x] Manually tested in the TUI (if UI change) — no Dock tile; playback, media keys and Control Center unaffected

Added `tests/test_services/test_macos_app.py` (4 tests): no-op off macOS, no-op without AppKit, asserts Accessory rather than Prohibited, and swallows AppKit errors.

## Related

No existing issue that I could find — happy to open one first if you'd prefer that order. Also glad to add a `CHANGELOG.md` entry; I left it out because the entries there are curated with attribution and PR numbers at release time, and I didn't want to guess at either.

Marked as **draft**: the diagnosis and the checks are complete, but I've only reproduced and verified this on one machine (macOS 15, Apple Silicon), so a second pair of eyes on an Intel Mac or a different macOS version would be worth having before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
