### PR TITLE
fix(playback): avoid ANDROID_VR 403s by using tv_simply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+### Unreleased
+
+**Fixes**
+
+- **Playback no longer 403s on current YouTube streams** — yt-dlp's default client set now includes `android_vr`, whose googlevideo URLs are rejected by mpv (`HTTP 403`, `rqh=1`). Stream resolution and offline downloads use `tv_simply` / `tv_downgraded` (legacy format 18) instead. Deno or Node is auto-detected for yt-dlp JS challenges when `[yt_dlp] js_runtimes` is unset.
+
+---
+
 ### v2.0.0 (2026-07-04)
 
 **New features**

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,18 @@
 # Troubleshooting
 
+## Playback fails with HTTP 403 (no sound)
+
+YouTube's default yt-dlp clients currently hand mpv stream URLs that 403
+(`c=ANDROID_VR`, `rqh=1`). ytm-player uses the `tv_simply` / `tv_downgraded`
+clients instead, which still serve legacy format 18.
+
+If playback still 403s:
+
+1. Update yt-dlp: `uv tool upgrade ytm-player` (or reinstall).
+2. Install a JS runtime yt-dlp can use for nsig solving (`deno` recommended, or `node`).
+3. On Arch, install `yt-dlp-ejs` so the challenge solver scripts are local.
+4. Restart `ytm` after changing yt-dlp or `[yt_dlp]` config — the resolver caches its YoutubeDL instance for the process lifetime.
+
 ## "mpv not found" or playback doesn't start
 
 Ensure mpv is installed and in your `$PATH`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "textual>=7.0,<9.0",
     "ytmusicapi>=1.11.0",
     "yt-dlp>=2025.1.0",
+    "yt-dlp-ejs>=0.8.0",
     "python-mpv>=1.0.0",
     "aiosqlite>=0.20.0",
     "click>=8.1.0",

--- a/src/ytm_player/services/download.py
+++ b/src/ytm_player/services/download.py
@@ -9,7 +9,10 @@ from pathlib import Path
 
 from ytm_player.config.paths import SECURE_FILE_MODE, secure_chmod
 from ytm_player.config.settings import get_settings
-from ytm_player.services.yt_dlp_options import apply_configured_yt_dlp_options
+from ytm_player.services.yt_dlp_options import (
+    apply_configured_yt_dlp_options,
+    youtube_extractor_args,
+)
 from ytm_player.utils.formatting import VALID_VIDEO_ID
 
 logger = logging.getLogger(__name__)
@@ -54,6 +57,7 @@ class DownloadService:
             "extract_flat": False,
             "writethumbnail": False,
             "writeinfojson": False,
+            "extractor_args": youtube_extractor_args(),
             "postprocessors": [
                 {
                     "key": "FFmpegExtractAudio",

--- a/src/ytm_player/services/stream.py
+++ b/src/ytm_player/services/stream.py
@@ -10,7 +10,10 @@ from dataclasses import dataclass
 from typing import Any
 
 from ytm_player.config.settings import get_settings
-from ytm_player.services.yt_dlp_options import apply_configured_yt_dlp_options
+from ytm_player.services.yt_dlp_options import (
+    apply_configured_yt_dlp_options,
+    youtube_extractor_args,
+)
 from ytm_player.utils.formatting import VALID_VIDEO_ID
 
 logger = logging.getLogger(__name__)
@@ -96,9 +99,9 @@ class StreamResolver:
             # Avoid writing any files to disk.
             "writeinfojson": False,
             "writethumbnail": False,
-            # Android client provides a non-PoT fallback path (legacy format 18)
-            # that unblocks madeForKids content which the default web client refuses.
-            "extractor_args": {"youtube": {"player_client": ["default", "android"]}},
+            # tv_simply/tv_downgraded expose legacy format 18. yt-dlp "default"
+            # includes android_vr, whose URLs 403 in mpv (rqh=1 + 1MB PO-token cap).
+            "extractor_args": youtube_extractor_args(),
         }
         return apply_configured_yt_dlp_options(opts, settings)
 

--- a/src/ytm_player/services/yt_dlp_options.py
+++ b/src/ytm_player/services/yt_dlp_options.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -12,6 +13,27 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+# yt-dlp's "default" client set currently includes android_vr. Those
+# googlevideo URLs 403 in mpv/ffmpeg (rqh=1 plus a ~1MB GVS PO-token cap).
+# tv_simply still exposes legacy format 18, which plays without a PO token.
+YOUTUBE_PLAYER_CLIENTS = ["tv_simply", "tv_downgraded"]
+
+_JS_RUNTIME_NAMES = ("deno", "node")
+
+
+def youtube_extractor_args() -> dict:
+    """Return extractor_args that avoid ANDROID_VR 403s in mpv."""
+    return {"youtube": {"player_client": list(YOUTUBE_PLAYER_CLIENTS)}}
+
+
+def detect_js_runtimes() -> dict[str, dict] | None:
+    """Return yt-dlp js_runtimes for JS engines found on PATH."""
+    found: dict[str, dict] = {}
+    for name in _JS_RUNTIME_NAMES:
+        if shutil.which(name):
+            found[name] = {}
+    return found or None
 
 
 def _split_csv_or_space(value: str) -> list[str]:
@@ -124,6 +146,8 @@ def apply_configured_yt_dlp_options(opts: dict, yt_dlp_settings: YtDlpSettings) 
         opts["remote_components"] = remote_components
 
     js_runtimes = normalize_js_runtimes(yt_dlp_settings.js_runtimes)
+    if js_runtimes is None:
+        js_runtimes = detect_js_runtimes()
     if js_runtimes:
         opts["js_runtimes"] = js_runtimes
 

--- a/tests/test_services/test_stream.py
+++ b/tests/test_services/test_stream.py
@@ -116,6 +116,31 @@ class TestStreamQuality:
             resolver.quality = "ultra"
 
 
+class TestYdlOpts:
+    """YouTube 403s ANDROID_VR progressive URLs in mpv (rqh=1 + 1MB cap).
+
+    tv_simply still offers legacy format 18, which mpv can play without a
+    PO token. See stream.py _build_ydl_opts.
+    """
+
+    def test_player_client_prefers_tv_simply_over_android_vr(self):
+        opts = StreamResolver()._build_ydl_opts()
+        clients = opts["extractor_args"]["youtube"]["player_client"]
+        assert "tv_simply" in clients
+        assert "android_vr" not in clients
+        assert "default" not in clients or ("-android_vr" in clients), (
+            "default includes android_vr, which 403s in mpv"
+        )
+
+    def test_js_runtimes_auto_detected_when_unset(self, monkeypatch):
+        monkeypatch.setattr(
+            "ytm_player.services.yt_dlp_options.shutil.which",
+            lambda name: "/usr/bin/deno" if name == "deno" else None,
+        )
+        opts = StreamResolver()._build_ydl_opts()
+        assert opts.get("js_runtimes") == {"deno": {}}
+
+
 class TestCacheEviction:
     def test_prune_expired(self):
         resolver = StreamResolver()

--- a/tests/test_services/test_yt_dlp_options.py
+++ b/tests/test_services/test_yt_dlp_options.py
@@ -83,10 +83,29 @@ def test_apply_configured_options_warns_when_remote_components_enabled(caplog):
     assert "remote_components is enabled" in caplog.text
 
 
-def test_apply_configured_options_skips_unset_fields():
+def test_apply_configured_options_skips_unset_fields(monkeypatch):
+    monkeypatch.setattr("ytm_player.services.yt_dlp_options.shutil.which", lambda _name: None)
     settings = YtDlpSettings()
     opts = apply_configured_yt_dlp_options({"quiet": True}, settings)
     assert opts == {"quiet": True}
+
+
+def test_apply_configured_options_autodetects_js_runtimes(monkeypatch):
+    monkeypatch.setattr(
+        "ytm_player.services.yt_dlp_options.shutil.which",
+        lambda name: "/usr/bin/deno" if name == "deno" else None,
+    )
+    opts = apply_configured_yt_dlp_options({"quiet": True}, YtDlpSettings())
+    assert opts["js_runtimes"] == {"deno": {}}
+
+
+def test_configured_js_runtimes_win_over_autodetect(monkeypatch):
+    monkeypatch.setattr(
+        "ytm_player.services.yt_dlp_options.shutil.which",
+        lambda name: "/usr/bin/deno" if name == "deno" else None,
+    )
+    opts = apply_configured_yt_dlp_options({"quiet": True}, YtDlpSettings(js_runtimes="node"))
+    assert opts["js_runtimes"] == {"node": {}}
 
 
 def test_normalize_cafile_expands_home():


### PR DESCRIPTION
## Summary

YouTube currently 403s the stream URLs ytm-player hands to mpv, so playback fails with no audio.

yt-dlp's `default` / `android` client set now includes `android_vr`. Those googlevideo URLs have `rqh=1` and a ~1MB GVS PO-token cap: mpv/ffmpeg GET without a closed Range header (and yt-dlp's own downloader) get `HTTP 403 Forbidden`. Small Range requests work for the first 1MB, then 403.

`tv_simply` / `tv_downgraded` still expose **legacy format 18**, which mpv can play without a PO token (`c=TVHTML5_SIMPLY`). This PR switches stream resolution and offline downloads to those clients.

## Changes

- Use `player_client: ["tv_simply", "tv_downgraded"]` for `StreamResolver` and `DownloadService`
- Auto-detect Deno/Node for yt-dlp JS challenges when `[yt_dlp] js_runtimes` is unset
- Depend on `yt-dlp-ejs` so nsig solving works without enabling `remote_components`
- Troubleshooting note + changelog

## Quality tradeoff

Format 18 is muxed 360p + **AAC ~128 kbps**. ytm-player already sets `video=False`, so only audio plays. This is worse than Opus 251, but 251 is what 403s today. A PO-token provider would be the longer-term path back to audio-only high quality.

## Test plan

- [x] Unit tests for extractor args + JS runtime autodetection (`tests/test_services/test_stream.py`, `test_yt_dlp_options.py`)
- [x] Resolved `4NTa0GRJMN8` via `StreamResolver` → `c=TVHTML5_SIMPLY`
- [x] `mpv --no-video --no-ytdl` played 3s of that URL (AAC 128 kbps)

Restart `ytm` after upgrading — the resolver caches its `YoutubeDL` instance for the process lifetime.