### PR TITLE
fix(macos): re-enable media-key event tap after OS disables it

### DIFF
--- a/src/ytm_player/services/macos_eventtap.py
+++ b/src/ytm_player/services/macos_eventtap.py
@@ -161,6 +161,21 @@ class MacOSEventTapService:
             logger.debug("Failed to invalidate macOS event tap", exc_info=True)
 
     def _tap_callback(self, _proxy: Any, event_type: int, event: Any, _refcon: Any) -> Any:
+        if event_type in (
+            Quartz.kCGEventTapDisabledByTimeout,
+            Quartz.kCGEventTapDisabledByUserInput,
+        ):
+            # macOS disables the tap if the callback doesn't return quickly enough
+            # (or on certain user-input floods). Without re-arming here, media keys
+            # silently fall through to Apple Music for the rest of the process's life.
+            if self._tap is not None:
+                try:
+                    Quartz.CGEventTapEnable(self._tap, True)
+                    logger.info("macOS disabled the media key event tap; re-enabled it")
+                except Exception:
+                    logger.debug("Failed to re-enable macOS event tap", exc_info=True)
+            return event
+
         if not self._running or event_type != Quartz.NSSystemDefined:
             return event
 

--- a/tests/test_services/test_macos_eventtap.py
+++ b/tests/test_services/test_macos_eventtap.py
@@ -62,7 +62,11 @@ class TestTapCallback:
         fake_appkit = SimpleNamespace(
             NSEvent=SimpleNamespace(eventWithCGEvent_=lambda _event: ns_event)
         )
-        fake_quartz = SimpleNamespace(NSSystemDefined=14)
+        fake_quartz = SimpleNamespace(
+            NSSystemDefined=14,
+            kCGEventTapDisabledByTimeout=0xFFFFFFFE,
+            kCGEventTapDisabledByUserInput=0xFFFFFFFF,
+        )
 
         with (
             patch("ytm_player.services.macos_eventtap.AppKit", fake_appkit),
@@ -72,6 +76,27 @@ class TestTapCallback:
 
         assert result is None
         await asyncio.wait_for(fired.wait(), timeout=1)
+
+    async def test_reenables_tap_after_timeout_disable(self) -> None:
+        svc = MacOSEventTapService()
+        svc._running = True
+        svc._loop = asyncio.get_running_loop()
+        svc._tap = object()
+
+        enabled_calls = []
+        fake_quartz = SimpleNamespace(
+            NSSystemDefined=14,
+            kCGEventTapDisabledByTimeout=0xFFFFFFFE,
+            kCGEventTapDisabledByUserInput=0xFFFFFFFF,
+            CGEventTapEnable=lambda tap, enabled: enabled_calls.append((tap, enabled)),
+        )
+        source_event = object()
+
+        with patch("ytm_player.services.macos_eventtap.Quartz", fake_quartz):
+            result = svc._tap_callback(None, 0xFFFFFFFE, source_event, None)
+
+        assert result is source_event
+        assert enabled_calls == [(svc._tap, True)]
 
     async def test_passthrough_when_not_mapped(self) -> None:
         svc = MacOSEventTapService()
@@ -85,7 +110,11 @@ class TestTapCallback:
         fake_appkit = SimpleNamespace(
             NSEvent=SimpleNamespace(eventWithCGEvent_=lambda _event: ns_event)
         )
-        fake_quartz = SimpleNamespace(NSSystemDefined=14)
+        fake_quartz = SimpleNamespace(
+            NSSystemDefined=14,
+            kCGEventTapDisabledByTimeout=0xFFFFFFFE,
+            kCGEventTapDisabledByUserInput=0xFFFFFFFF,
+        )
 
         with (
             patch("ytm_player.services.macos_eventtap.AppKit", fake_appkit),


### PR DESCRIPTION
## Summary
- macOS disables a `CGEventTap` (`kCGEventTapDisabledByTimeout` / `kCGEventTapDisabledByUserInput`) if the callback doesn't respond fast enough or on certain user-input floods; `_tap_callback` never checked for these, so once disabled, media keys silently fell through to Apple Music for the rest of the process's life with no error or log line
- Re-arm the tap via `CGEventTapEnable` when either disable event fires, with a log line so it's visible if it happens again
- Added a regression test covering the re-enable path