### PR TITLE
fix(queue): explicit play starts unshuffled unless the collection has a saved shuffle pref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 **Fixes**
 
 - **Playback failed with `HTTP error 403 Forbidden` on every track** (#140, #142) — YouTube started rejecting streams from yt-dlp's former default client on 2026-08-17; yt-dlp 2026.08.19 dropped that client. ytm-player now requires `yt-dlp>=2026.8.19`, so upgrading ytm-player pulls in the fix. Per-installer upgrade steps: [Troubleshooting](docs/troubleshooting.md#playback-fails-with-http-error-403-forbidden).
+- **Explicit play inherited last session's shuffle** — double-clicking a playlist (or playing any album, artist, or page selection) kept whatever shuffle state was left over, so the queue showed a shuffled order with no hint why. Explicit play now starts unshuffled unless that collection has a saved shuffle preference; the toast reads `Playing: <name> (shuffled)` when shuffle is on.
 
 ### v2.0.0 (2026-07-04)
 

--- a/src/ytm_player/app/_track_actions.py
+++ b/src/ytm_player/app/_track_actions.py
@@ -259,7 +259,9 @@ class TrackActionsMixin(YTMHostBase):
             # saved OFF must clear a currently-ON shuffle, not just force ON.
             if self.queue.shuffle_enabled != saved_pref:
                 self.queue.toggle_shuffle()
-        elif shuffle is False:
+        elif shuffle is None or shuffle is False:
+            # Without a per-collection preference, explicit play starts unshuffled so a
+            # previous session's or collection's global flag cannot leak into the new queue.
             if self.queue.shuffle_enabled:
                 self.queue.toggle_shuffle()
         self.queue.jump_to_real(start_index)
@@ -748,7 +750,8 @@ class TrackActionsMixin(YTMHostBase):
                 self.notify("Playlist is empty", severity="warning")
                 return
             await self._replace_queue_and_play(tracks, entity_id=playlist_id, shuffle=shuffle)
-            self.notify(f"Playing: {name}", timeout=4)
+            suffix = " (shuffled)" if self.queue.shuffle_enabled else ""
+            self.notify(f"Playing: {name}{suffix}", timeout=4)
             total_count = data.get("trackCount") or len(raw_tracks)
             if total_count > len(raw_tracks):
                 self.run_worker(

--- a/tests/test_app/test_artist_actions.py
+++ b/tests/test_app/test_artist_actions.py
@@ -432,6 +432,7 @@ class TestPlayPlaylist:
         host.ytmusic = MagicMock()
         host.ytmusic.get_playlist = AsyncMock(return_value=get_playlist_return or {})
         host._replace_queue_and_play = AsyncMock()
+        host.queue.shuffle_enabled = False
         host.notify = MagicMock()
         host.run_worker = MagicMock()
         return host

--- a/tests/test_app/test_play_playlist_toast.py
+++ b/tests/test_app/test_play_playlist_toast.py
@@ -1,0 +1,46 @@
+"""Tests for playlist playback notifications."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ytm_player.app._track_actions import TrackActionsMixin
+from ytm_player.services.queue import QueueManager
+
+
+def _make_host(saved_pref: bool | None) -> MagicMock:
+    host = MagicMock()
+    host.ytmusic = MagicMock()
+    host.ytmusic.get_playlist = AsyncMock(
+        return_value={
+            "tracks": [
+                {"videoId": "v1", "title": "T1", "artists": [{"name": "A", "id": "a"}]},
+                {"videoId": "v2", "title": "T2", "artists": [{"name": "A", "id": "a"}]},
+            ],
+            "trackCount": 2,
+        }
+    )
+    host.queue = QueueManager()
+    host.shuffle_prefs = MagicMock()
+    host.shuffle_prefs.get = MagicMock(return_value=saved_pref)
+    host.play_track = AsyncMock()
+    host._refresh_queue_page = MagicMock()
+    host._sync_shuffle_bar = MagicMock()
+    host.notify = MagicMock()
+    host.run_worker = MagicMock()
+    host._replace_queue_and_play = TrackActionsMixin._replace_queue_and_play.__get__(host)
+    return host
+
+
+@pytest.mark.parametrize(
+    ("saved_pref", "expected_message"),
+    [(True, "Playing: Pangaea (shuffled)"), (None, "Playing: Pangaea")],
+)
+async def test_play_playlist_toast_reflects_shuffle_state(saved_pref, expected_message):
+    host = _make_host(saved_pref)
+
+    await TrackActionsMixin._play_playlist(host, "PL1", "Pangaea")
+
+    host.notify.assert_called_once_with(expected_message, timeout=4)

--- a/tests/test_ui/test_play_selected_unified.py
+++ b/tests/test_ui/test_play_selected_unified.py
@@ -92,6 +92,44 @@ async def test_helper_still_forces_saved_shuffle_on():
     assert host.queue.shuffle_enabled is True
 
 
+async def test_helper_explicit_collection_play_clears_unsaved_shuffle():
+    queue = QueueManager()
+    queue.toggle_shuffle()
+    host = _make_host(queue=queue)
+
+    await TrackActionsMixin._replace_queue_and_play(
+        host, [_track("a"), _track("b")], entity_id="PL1", shuffle=None, autoplay=False
+    )
+
+    assert host.queue.shuffle_enabled is False
+    host._sync_shuffle_bar.assert_called_once()
+
+
+async def test_helper_explicit_collection_play_preserves_saved_shuffle_on():
+    queue = QueueManager()
+    queue.toggle_shuffle()
+    host = _make_host(queue=queue)
+    host.shuffle_prefs.get = MagicMock(return_value=True)
+
+    await TrackActionsMixin._replace_queue_and_play(
+        host, [_track("a"), _track("b")], entity_id="PL1", shuffle=None, autoplay=False
+    )
+
+    assert host.queue.shuffle_enabled is True
+
+
+async def test_helper_explicit_non_collection_play_clears_unsaved_shuffle():
+    queue = QueueManager()
+    queue.toggle_shuffle()
+    host = _make_host(queue=queue)
+
+    await TrackActionsMixin._replace_queue_and_play(
+        host, [_track("a"), _track("b")], entity_id=None, shuffle=None, autoplay=False
+    )
+
+    assert host.queue.shuffle_enabled is False
+
+
 async def test_helper_explicit_shuffle_with_saved_off_pref():
     """Explicit shuffle=True pre-randomizes the track list; the saved-OFF
     pref then clears the queue's shuffle MODE without defeating the


### PR DESCRIPTION
Double-clicking a playlist (or playing any album, artist, or page selection) kept whatever shuffle state was left over from the previous session, so the queue showed a shuffled order with no hint why.

- `_replace_queue_and_play`: with no per-collection shuffle preference, explicit play now starts unshuffled (previously it inherited the global flag). Saved preferences still win in both directions. Queue-page jumps and session resume do not go through this helper and keep their shuffle state.
- `_play_playlist` toast reads `Playing: <name> (shuffled)` when shuffle is on after the play starts.
- Regression tests for unsaved/saved/non-collection cases and the toast text.