### PR TITLE
fix(sidebar): double-click fired two single-click selections plus the double-click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 **Fixes**
 
+- **Double-clicking a sidebar playlist loaded it three times** — one double-click fired two single-click selections plus the double-click, starting three concurrent playlist fetches. It now fires exactly one selection and one double-click.
 - **Playback failed with `HTTP error 403 Forbidden` on every track** (#140, #142) — YouTube started rejecting streams from yt-dlp's former default client on 2026-08-17; yt-dlp 2026.08.19 dropped that client. ytm-player now requires `yt-dlp>=2026.8.19`, so upgrading ytm-player pulls in the fix. Per-installer upgrade steps: [Troubleshooting](docs/troubleshooting.md#playback-fails-with-http-error-403-forbidden).
 - **Explicit play inherited last session's shuffle** — double-clicking a playlist (or playing any album, artist, or page selection) kept whatever shuffle state was left over, so the queue showed a shuffled order with no hint why. Explicit play now starts unshuffled unless that collection has a saved shuffle preference; the toast reads `Playing: <name> (shuffled)` when shuffle is on.
 

--- a/src/ytm_player/ui/sidebars/playlist_sidebar.py
+++ b/src/ytm_player/ui/sidebars/playlist_sidebar.py
@@ -132,6 +132,7 @@ class LibraryPanel(Widget):
         self._last_click_time: float = 0.0
         self._last_click_index: int | None = None
         self._click_activated: bool = False
+        self._suppress_next_selected: bool = False
 
     def compose(self) -> ComposeResult:
         yield Label(self._title, classes="panel-title")
@@ -358,6 +359,9 @@ class LibraryPanel(Widget):
 
     def on_list_view_selected(self, event: ListView.Selected) -> None:
         if self._instant_select:
+            if self._suppress_next_selected:
+                self._suppress_next_selected = False
+                return
             idx = event.list_view.index
             if idx is not None and 0 <= idx < len(self._filtered_items):
                 self.post_message(self.ItemSelected(self._filtered_items[idx], self.id or ""))
@@ -402,10 +406,12 @@ class LibraryPanel(Widget):
                     self._last_click_time = 0.0
                     self._last_click_index = None
                     event.stop()
+                    self._suppress_next_selected = True
                     self.post_message(
                         self.ItemDoubleClicked(self._filtered_items[idx], self.id or "")
                     )
                     return
+                self._suppress_next_selected = False
                 self._last_click_time = now
                 self._last_click_index = idx
             return

--- a/tests/test_ui/test_playlist_sidebar_clicks.py
+++ b/tests/test_ui/test_playlist_sidebar_clicks.py
@@ -1,0 +1,78 @@
+"""Tests for LibraryPanel click message handling."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from ytm_player.ui.sidebars import playlist_sidebar
+from ytm_player.ui.sidebars.playlist_sidebar import LibraryPanel
+
+
+def _make_panel(monkeypatch) -> LibraryPanel:
+    panel = LibraryPanel("Library", instant_select=True)
+    panel._filtered_items = [{"playlistId": "PL1", "title": "A"}]
+    monkeypatch.setattr(panel, "_find_clicked_item_index", MagicMock(return_value=0))
+    monkeypatch.setattr(panel, "post_message", MagicMock())
+    return panel
+
+
+def _make_click():
+    return MagicMock(button=1)
+
+
+def _make_selected():
+    return MagicMock(list_view=MagicMock(index=0))
+
+
+def _posted_message_types(panel: LibraryPanel) -> list[type]:
+    return [type(call.args[0]) for call in panel.post_message.call_args_list]
+
+
+def test_single_click_posts_one_selected(monkeypatch):
+    panel = _make_panel(monkeypatch)
+    monkeypatch.setattr(playlist_sidebar.time, "monotonic", MagicMock(return_value=1.0))
+
+    panel.on_click(_make_click())
+    panel.on_list_view_selected(_make_selected())
+
+    assert _posted_message_types(panel) == [LibraryPanel.ItemSelected]
+
+
+def test_double_click_posts_selected_then_double_clicked(monkeypatch):
+    panel = _make_panel(monkeypatch)
+    monkeypatch.setattr(playlist_sidebar.time, "monotonic", MagicMock(side_effect=[1.0, 1.2]))
+    first_click = _make_click()
+    second_click = _make_click()
+
+    panel.on_click(first_click)
+    panel.on_list_view_selected(_make_selected())
+    panel.on_click(second_click)
+    panel.on_list_view_selected(_make_selected())
+
+    assert _posted_message_types(panel) == [
+        LibraryPanel.ItemSelected,
+        LibraryPanel.ItemDoubleClicked,
+    ]
+    second_click.stop.assert_called_once_with()
+
+
+def test_single_click_after_double_click_posts_selected(monkeypatch):
+    panel = _make_panel(monkeypatch)
+    monkeypatch.setattr(
+        playlist_sidebar.time,
+        "monotonic",
+        MagicMock(side_effect=[1.0, 1.2, 2.0]),
+    )
+
+    panel.on_click(_make_click())
+    panel.on_list_view_selected(_make_selected())
+    panel.on_click(_make_click())
+    panel.on_list_view_selected(_make_selected())
+    panel.on_click(_make_click())
+    panel.on_list_view_selected(_make_selected())
+
+    assert _posted_message_types(panel) == [
+        LibraryPanel.ItemSelected,
+        LibraryPanel.ItemDoubleClicked,
+        LibraryPanel.ItemSelected,
+    ]


### PR DESCRIPTION
One double-click on a sidebar playlist fired two single-click selections plus the double-click, starting three concurrent playlist fetches.

- `LibraryPanel` (instant-select mode): the double-click branch of `on_click` now sets a one-shot flag that `on_list_view_selected` consumes, so the second click's `ListView.Selected` is dropped. A fresh single click resets the flag. The second `Click` cannot be stopped earlier because `ListItem` handles it first and posts `Selected` from there.
- Regression tests: single click → one selection; double click → one selection + one double-click, `Click.stop()` called; single click after a double-click selects again.