### PR TITLE
macOS: media-key tap re-arm, Now Playing run-loop pump, no Dock icon (combined test branch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,4 @@ jobs:
       # #106 platform-guard test teeth: it proves the forced-win32/darwin import
       # never pulls dbus-fast in even when it's present. macOS/Windows runners
       # correctly never install it (sys_platform marker).
-      - run: pytest --cov=ytm_player --cov-report=term-missing
+      - run: pytest -rs --cov=ytm_player --cov-report=term-missing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - **yt-dlp's own warnings and errors now reach `ytm.log`** — yt-dlp's default logger dropped them, so failures like "Signature solving failed" or "Skipping client … since it does not support cookies" left no trace. Thanks @wgordon17 (#136).
 - **Stream resolver reset fixes** — resetting the resolver (a quality change, or the automatic reset after repeated failures) no longer closes the yt-dlp instance under a resolve that is still running (a ~30 s stall), no longer loses a reset that lands while the instance is being built, and a resolve that finishes after a reset no longer puts its result back into the cleared cache. Concurrent resolves are serialized on the shared yt-dlp instance, which is not thread-safe. Thanks @wgordon17 (#136).
 - **`pycryptodomex` is now a core dependency** — yt-dlp uses it to decrypt Chromium cookies during `ytm setup`; without it the pure-Python fallback took ~26 s instead of ~2 s on a large profile. Thanks @wgordon17 (#136).
-- **macOS Now Playing stays active** — the Cocoa main run loop is serviced alongside Textual's asyncio loop, so published track metadata appears reliably in Control Center.
+- **macOS media keys stopped working after a while** — macOS disables the media-key event tap when a callback is slow or during an input flood, and nothing re-enabled it, so the keys silently went to Apple Music for the rest of the session. The tap is re-enabled as soon as macOS reports it disabled. Thanks @wgordon17 (#141).
+- **macOS Now Playing stays active** — the Cocoa main run loop is serviced alongside Textual's asyncio loop, so published track metadata appears reliably in Control Center. Thanks @alvaro0x404 (#131).
+- **Phantom bouncing "Python" Dock icon on macOS** — creating the mpv handle promotes the process to a foreground app and nothing ever finishes that launch, so a generic Python tile bounced in the Dock indefinitely. The process is demoted to an accessory app (no Dock tile, still a Now Playing source) once mpv is up. Thanks @aksholokhov (#128).
 
 ### v2.0.0 (2026-07-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - **yt-dlp's own warnings and errors now reach `ytm.log`** — yt-dlp's default logger dropped them, so failures like "Signature solving failed" or "Skipping client … since it does not support cookies" left no trace. Thanks @wgordon17 (#136).
 - **Stream resolver reset fixes** — resetting the resolver (a quality change, or the automatic reset after repeated failures) no longer closes the yt-dlp instance under a resolve that is still running (a ~30 s stall), no longer loses a reset that lands while the instance is being built, and a resolve that finishes after a reset no longer puts its result back into the cleared cache. Concurrent resolves are serialized on the shared yt-dlp instance, which is not thread-safe. Thanks @wgordon17 (#136).
 - **`pycryptodomex` is now a core dependency** — yt-dlp uses it to decrypt Chromium cookies during `ytm setup`; without it the pure-Python fallback took ~26 s instead of ~2 s on a large profile. Thanks @wgordon17 (#136).
+- **macOS Now Playing stays active** — the Cocoa main run loop is serviced alongside Textual's asyncio loop, so published track metadata appears reliably in Control Center.
 
 ### v2.0.0 (2026-07-04)
 

--- a/src/ytm_player/services/macos_app.py
+++ b/src/ytm_player/services/macos_app.py
@@ -1,0 +1,47 @@
+"""
+Purpose: Keep the ytm-player process out of the macOS Dock and app switcher.
+Interface: hide_dock_icon().
+Invariants: No-op off macOS and when AppKit is unavailable; never raises.
+Decisions: Use Accessory rather than Prohibited so the process stays a real,
+activatable app and can still serve MPRemoteCommandCenter / Now Playing.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+try:
+    _APPKIT: Any = importlib.import_module("AppKit")
+
+    _APPKIT_AVAILABLE = True
+except ImportError:
+    _APPKIT = None
+    _APPKIT_AVAILABLE = False
+
+# NSApplicationActivationPolicyAccessory: the process runs without a Dock tile
+# and without an app-switcher entry, but stays activatable — unlike Prohibited,
+# which would also make it ineligible as a Now Playing source.
+_ACTIVATION_POLICY_ACCESSORY = 1
+
+
+def hide_dock_icon() -> bool:
+    """Demote this process to an accessory app, so macOS gives it no Dock tile.
+
+    Returns True if the activation policy was applied, False if it wasn't
+    needed (non-macOS) or couldn't be (AppKit missing, or the call failed).
+    """
+    if sys.platform != "darwin" or not _APPKIT_AVAILABLE:
+        return False
+    try:
+        app = _APPKIT.NSApplication.sharedApplication()
+        app.setActivationPolicy_(_ACTIVATION_POLICY_ACCESSORY)
+    except Exception:
+        logger.debug("Could not set macOS activation policy", exc_info=True)
+        return False
+    logger.info("macOS activation policy set to accessory (no Dock icon)")
+    return True

--- a/src/ytm_player/services/macos_app.py
+++ b/src/ytm_player/services/macos_app.py
@@ -1,7 +1,8 @@
 """
 Purpose: Keep the ytm-player process out of the macOS Dock and app switcher.
 Interface: hide_dock_icon().
-Invariants: No-op off macOS and when AppKit is unavailable; never raises.
+Invariants: No-op off macOS, when AppKit is unavailable, and off the main thread;
+never raises.
 Decisions: Use Accessory rather than Prohibited so the process stays a real,
 activatable app and can still serve MPRemoteCommandCenter / Now Playing.
 """
@@ -11,6 +12,7 @@ from __future__ import annotations
 import importlib
 import logging
 import sys
+import threading
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -32,16 +34,24 @@ _ACTIVATION_POLICY_ACCESSORY = 1
 def hide_dock_icon() -> bool:
     """Demote this process to an accessory app, so macOS gives it no Dock tile.
 
-    Returns True if the activation policy was applied, False if it wasn't
-    needed (non-macOS) or couldn't be (AppKit missing, or the call failed).
+    Returns True only when AppKit reports the policy switch succeeded;
+    False when it wasn't needed (non-macOS), couldn't be attempted (AppKit
+    missing, not on the main thread -- AppKit is main-thread-only, so this
+    is never called from a worker), or was refused or failed.
     """
     if sys.platform != "darwin" or not _APPKIT_AVAILABLE:
         return False
+    if threading.current_thread() is not threading.main_thread():
+        logger.debug("Not setting the macOS activation policy off the main thread")
+        return False
     try:
         app = _APPKIT.NSApplication.sharedApplication()
-        app.setActivationPolicy_(_ACTIVATION_POLICY_ACCESSORY)
+        switched = app.setActivationPolicy_(_ACTIVATION_POLICY_ACCESSORY)
     except Exception:
         logger.debug("Could not set macOS activation policy", exc_info=True)
+        return False
+    if not switched:
+        logger.warning("macOS refused the accessory activation policy; the Dock icon stays")
         return False
     logger.info("macOS activation policy set to accessory (no Dock icon)")
     return True

--- a/src/ytm_player/services/macos_eventtap.py
+++ b/src/ytm_player/services/macos_eventtap.py
@@ -161,6 +161,21 @@ class MacOSEventTapService:
             logger.debug("Failed to invalidate macOS event tap", exc_info=True)
 
     def _tap_callback(self, _proxy: Any, event_type: int, event: Any, _refcon: Any) -> Any:
+        if event_type in (
+            Quartz.kCGEventTapDisabledByTimeout,
+            Quartz.kCGEventTapDisabledByUserInput,
+        ):
+            # macOS disables the tap if the callback doesn't return quickly enough
+            # (or on certain user-input floods). Without re-arming here, media keys
+            # silently fall through to Apple Music for the rest of the process's life.
+            if self._tap is not None:
+                try:
+                    Quartz.CGEventTapEnable(self._tap, True)
+                    logger.info("macOS disabled the media key event tap; re-enabled it")
+                except Exception:
+                    logger.debug("Failed to re-enable macOS event tap", exc_info=True)
+            return event
+
         if not self._running or event_type != Quartz.NSSystemDefined:
             return event
 

--- a/src/ytm_player/services/macos_media.py
+++ b/src/ytm_player/services/macos_media.py
@@ -2,7 +2,8 @@
 Purpose: Integrate ytm-player with macOS media keys and Now Playing center.
 Interface: MacOSMediaService.start/stop/update_metadata/update_playback_status/update_position.
 Invariants: Missing MediaPlayer bindings degrade to no-op behavior without crashing the app.
-Decisions: Keep metadata updates local (no artwork download) and dispatch callbacks on the app loop.
+Decisions: Keep metadata updates local (no artwork download), dispatch callbacks on the app loop,
+and briefly pump Cocoa's main run loop without blocking Textual.
 """
 
 from __future__ import annotations
@@ -10,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import logging
+import threading
 from typing import Any
 
 from ytm_player.services._dispatch import (
@@ -27,6 +29,11 @@ try:
 except ImportError:
     _MP = None
     _MEDIA_PLAYER_AVAILABLE = False
+
+try:
+    _FOUNDATION = importlib.import_module("Foundation")
+except ImportError:
+    _FOUNDATION = None
 
 _STATUS_SUCCESS = 0
 _STATUS_FAILED = 200
@@ -69,6 +76,7 @@ class MacOSMediaService:
         self._registered_targets: list[tuple[Any, Any]] = []
         self._now_playing: dict[str, Any] = {}
         self._is_playing = False
+        self._run_loop_task: asyncio.Task[None] | None = None
 
     async def start(
         self,
@@ -78,6 +86,8 @@ class MacOSMediaService:
         """Register MPRemoteCommandCenter handlers."""
         if not _MEDIA_PLAYER_AVAILABLE:
             logger.info("MediaPlayer framework bindings not installed — macOS media keys disabled")
+            return
+        if self._running:
             return
 
         self._callbacks = callbacks
@@ -99,12 +109,23 @@ class MacOSMediaService:
 
         self._running = True
         self._publish_now_playing()
+        if _FOUNDATION is not None:
+            if threading.current_thread() is threading.main_thread():
+                self._run_loop_task = loop.create_task(self._pump_run_loop())
+            else:
+                logger.warning("macOS Now Playing requires the asyncio loop on the main thread")
         logger.info("macOS media key integration enabled")
 
     def stop(self) -> None:
         """Unregister command handlers and clear Now Playing state."""
         if not _MEDIA_PLAYER_AVAILABLE:
             return
+
+        self._running = False
+        if self._run_loop_task is not None:
+            self._run_loop_task.cancel()
+            self._run_loop_task = None
+
         mp = _MP
         if mp is None:
             return
@@ -121,10 +142,31 @@ class MacOSMediaService:
         except Exception:
             logger.debug("Failed to clear macOS Now Playing info", exc_info=True)
 
-        self._running = False
         self._now_playing.clear()
         self._is_playing = False
         logger.info("macOS media key integration stopped")
+
+    async def _pump_run_loop(self) -> None:
+        """Let MediaPlayer service Cocoa callbacks alongside Textual's asyncio loop."""
+        foundation = _FOUNDATION
+        if foundation is None:
+            return
+        run_loop = foundation.NSRunLoop.mainRunLoop()
+        task = asyncio.current_task()
+        try:
+            while self._running:
+                run_loop.runMode_beforeDate_(
+                    foundation.NSDefaultRunLoopMode,
+                    foundation.NSDate.date(),
+                )
+                await asyncio.sleep(0.5)
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.exception("Failed to pump macOS main run loop")
+        finally:
+            if self._run_loop_task is task:
+                self._run_loop_task = None
 
     async def update_metadata(
         self,

--- a/src/ytm_player/services/player.py
+++ b/src/ytm_player/services/player.py
@@ -14,6 +14,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from ytm_player.services.macos_app import hide_dock_icon
 from ytm_player.utils.compat import StrEnum, auto
 
 if sys.platform == "win32":
@@ -260,6 +261,13 @@ class Player:
             log_handler=_on_mpv_log,
             loglevel="warn",
         )
+
+        # Creating the mpv handle initialises Cocoa in-process, which promotes
+        # this process to a foreground GUI app: macOS then shows a generic
+        # "Python" Dock tile that bounces indefinitely, because nothing ever
+        # signals that app launch finished.  Demote it now that mpv is up —
+        # doing this earlier is useless, since libmpv re-promotes it.
+        hide_dock_icon()
 
         # Enable gapless playback if configured.
         if settings.playback.gapless:

--- a/src/ytm_player/services/player.py
+++ b/src/ytm_player/services/player.py
@@ -183,6 +183,9 @@ class Player:
             event: [] for event in PlayerEvent
         }
         self._loop: asyncio.AbstractEventLoop | None = None
+        # Thread the loop runs on (recorded by set_event_loop); the Dock
+        # policy is handed to the loop only when that is the main thread.
+        self._loop_thread: threading.Thread | None = None
         # Context (captured when the loop is set, i.e. inside the running
         # Textual app) used to dispatch callbacks. Without it, callbacks
         # scheduled from mpv's thread run without Textual's ``active_app``
@@ -267,7 +270,7 @@ class Player:
         # "Python" Dock tile that bounces indefinitely, because nothing ever
         # signals that app launch finished.  Demote it now that mpv is up —
         # doing this earlier is useless, since libmpv re-promotes it.
-        hide_dock_icon()
+        self._apply_dock_policy()
 
         # Enable gapless playback if configured.
         if settings.playback.gapless:
@@ -342,10 +345,32 @@ class Player:
         even though the event originates on mpv's callback thread.
         """
         self._loop = loop
+        self._loop_thread = threading.current_thread()
         try:
             self._dispatch_context = contextvars.copy_context()
         except Exception:
             self._dispatch_context = None
+
+    def _apply_dock_policy(self) -> None:
+        """Run hide_dock_icon() on the main thread, or not at all.
+
+        AppKit is main-thread-only. The startup call from __init__ is
+        already on the main thread; the one after an mpv recovery comes
+        from the worker thread running _play_sync and is handed to the
+        app's event loop, which runs on the main thread. Without such a
+        route the policy is skipped rather than applied from the worker.
+        """
+        if threading.current_thread() is threading.main_thread():
+            hide_dock_icon()
+            return
+        loop = self._get_loop()
+        if loop is not None and self._loop_thread is threading.main_thread():
+            try:
+                loop.call_soon_threadsafe(hide_dock_icon)
+                return
+            except RuntimeError:
+                pass  # loop closed between the check and the call
+        logger.debug("No main-thread route for the macOS Dock policy; leaving it")
 
     # ── Callback registration ───────────────────────────────────────
 

--- a/tests/test_services/_macos_smoke_child.py
+++ b/tests/test_services/_macos_smoke_child.py
@@ -1,0 +1,155 @@
+"""Child-process half of the macOS real-framework smoke test.
+
+Run as ``python _macos_smoke_child.py <case>`` by test_macos_smoke.py, one
+process per case, so the framework calls run on a fresh main thread and the
+parent can enforce a wall-clock timeout by killing the process -- the calls
+are synchronous, so nothing inside the process could interrupt them.
+
+Prints one JSON object on stdout. Exit status: 0 with a result, 2 when a
+framework is not importable (message on stderr), 1 on any other failure
+(traceback on stderr). Not collected by pytest (no ``test_`` prefix).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import sys
+import threading
+import time
+from typing import Any
+
+_ACCESSORY = 1
+
+
+def _framework(name: str) -> Any:
+    try:
+        return importlib.import_module(name)
+    except ImportError as exc:
+        print(f"{name} is not importable: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+
+def _on_main_thread() -> bool:
+    return threading.current_thread() is threading.main_thread()
+
+
+def dock() -> dict[str, Any]:
+    """Apply the accessory policy, read it back, restore the previous one."""
+    appkit = _framework("AppKit")
+    from ytm_player.services import macos_app
+    from ytm_player.services.macos_app import hide_dock_icon
+
+    app = appkit.NSApplication.sharedApplication()
+    previous = int(app.activationPolicy())
+    result: dict[str, Any] = {
+        "appkit_available": macos_app._APPKIT_AVAILABLE,
+        "main_thread": _on_main_thread(),
+        "previous": previous,
+    }
+    try:
+        result["switched"] = bool(hide_dock_icon())
+        result["policy_after"] = int(app.activationPolicy())
+    finally:
+        result["restored"] = bool(app.setActivationPolicy_(previous))
+        result["policy_final"] = int(app.activationPolicy())
+    return result
+
+
+async def _media() -> dict[str, Any]:
+    mp = _framework("MediaPlayer")
+    foundation = _framework("Foundation")
+    from ytm_player.services import macos_media
+    from ytm_player.services.macos_media import MacOSMediaService
+
+    center = mp.MPNowPlayingInfoCenter.defaultCenter()
+    result: dict[str, Any] = {
+        "media_player_available": macos_media._MEDIA_PLAYER_AVAILABLE,
+        "foundation_available": macos_media._FOUNDATION is not None,
+        "main_thread": _on_main_thread(),
+        "main_run_loop": foundation.NSRunLoop.mainRunLoop() is not None,
+    }
+    service = MacOSMediaService()
+    pump: asyncio.Task[None] | None = None
+    try:
+        await service.start({}, asyncio.get_running_loop())
+        pump = service._run_loop_task
+        result["running"] = service._running
+        result["registered"] = len(service._registered_targets)
+        result["pump_started"] = pump is not None
+
+        await service.update_metadata("Smoke title", "Smoke artist", "Smoke album", 90_000_000)
+        info = center.nowPlayingInfo()
+        result["published"] = None if info is None else {str(k): _plain(v) for k, v in info.items()}
+
+        await service.update_playback_status("playing")
+        info = center.nowPlayingInfo()
+        result["rate_after_playing"] = (
+            None if info is None else _plain(info.get(macos_media._RATE_KEY))
+        )
+        result["state_after_playing"] = (
+            int(center.playbackState()) if hasattr(center, "playbackState") else None
+        )
+        result["state_playing_const"] = (
+            None
+            if macos_media._PLAYBACK_STATE_PLAYING is None
+            else int(macos_media._PLAYBACK_STATE_PLAYING)
+        )
+
+        # Two pump intervals of real runMode:beforeDate: calls.
+        await asyncio.sleep(1.1)
+        result["pump_alive_after_pumping"] = pump is not None and not pump.done()
+    finally:
+        service.stop()
+        if pump is not None:
+            try:
+                await pump
+            except asyncio.CancelledError:
+                pass
+            result["pump_finished_after_stop"] = pump.done()
+    result["running_after_stop"] = service._running
+    result["targets_after_stop"] = len(service._registered_targets)
+    result["info_after_stop"] = center.nowPlayingInfo() is not None
+    return result
+
+
+def _plain(value: Any) -> Any:
+    """JSON-friendly copy of an Objective-C bridged scalar."""
+    if isinstance(value, bool | int | float | str) or value is None:
+        return value
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def media() -> dict[str, Any]:
+    return asyncio.run(_media())
+
+
+def tap_constants() -> dict[str, Any]:
+    """The re-enable branch's constants exist; no tap is created (see the test)."""
+    quartz = _framework("Quartz")
+    return {
+        "has_timeout_const": hasattr(quartz, "kCGEventTapDisabledByTimeout"),
+        "has_user_input_const": hasattr(quartz, "kCGEventTapDisabledByUserInput"),
+    }
+
+
+def hang() -> dict[str, Any]:
+    """Harness self-check: a synchronous block the parent must be able to kill."""
+    time.sleep(60)
+    return {"unreachable": True}
+
+
+CASES = {"dock": dock, "media": media, "tap_constants": tap_constants, "hang": hang}
+
+
+def main() -> None:
+    case = CASES[sys.argv[1]]
+    print(json.dumps(case()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_services/test_macos_app.py
+++ b/tests/test_services/test_macos_app.py
@@ -1,0 +1,45 @@
+"""Tests for ytm_player.services.macos_app."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from ytm_player.services import macos_app
+from ytm_player.services.macos_app import hide_dock_icon
+
+
+class TestHideDockIcon:
+    def test_noop_off_macos(self) -> None:
+        with patch.object(macos_app.sys, "platform", "linux"):
+            assert hide_dock_icon() is False
+
+    def test_noop_when_appkit_unavailable(self) -> None:
+        with (
+            patch.object(macos_app.sys, "platform", "darwin"),
+            patch.object(macos_app, "_APPKIT_AVAILABLE", False),
+        ):
+            assert hide_dock_icon() is False
+
+    def test_sets_accessory_policy_on_macos(self) -> None:
+        app = MagicMock()
+        appkit = MagicMock()
+        appkit.NSApplication.sharedApplication.return_value = app
+        with (
+            patch.object(macos_app.sys, "platform", "darwin"),
+            patch.object(macos_app, "_APPKIT_AVAILABLE", True),
+            patch.object(macos_app, "_APPKIT", appkit),
+        ):
+            assert hide_dock_icon() is True
+        # Accessory (1), not Prohibited (2): Prohibited would also make the
+        # process ineligible as a Now Playing source.
+        app.setActivationPolicy_.assert_called_once_with(1)
+
+    def test_swallows_appkit_errors(self) -> None:
+        appkit = MagicMock()
+        appkit.NSApplication.sharedApplication.side_effect = RuntimeError("no window server")
+        with (
+            patch.object(macos_app.sys, "platform", "darwin"),
+            patch.object(macos_app, "_APPKIT_AVAILABLE", True),
+            patch.object(macos_app, "_APPKIT", appkit),
+        ):
+            assert hide_dock_icon() is False

--- a/tests/test_services/test_macos_app.py
+++ b/tests/test_services/test_macos_app.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import threading
 from unittest.mock import MagicMock, patch
 
 from ytm_player.services import macos_app
@@ -22,6 +24,7 @@ class TestHideDockIcon:
 
     def test_sets_accessory_policy_on_macos(self) -> None:
         app = MagicMock()
+        app.setActivationPolicy_.return_value = True
         appkit = MagicMock()
         appkit.NSApplication.sharedApplication.return_value = app
         with (
@@ -33,6 +36,37 @@ class TestHideDockIcon:
         # Accessory (1), not Prohibited (2): Prohibited would also make the
         # process ineligible as a Now Playing source.
         app.setActivationPolicy_.assert_called_once_with(1)
+
+    def test_rejected_policy_change_returns_false_and_warns(self, caplog) -> None:
+        # setActivationPolicy: "true if the policy switch succeeded;
+        # otherwise, false" -- a refusal must not be reported as applied.
+        app = MagicMock()
+        app.setActivationPolicy_.return_value = False
+        appkit = MagicMock()
+        appkit.NSApplication.sharedApplication.return_value = app
+        with (
+            patch.object(macos_app.sys, "platform", "darwin"),
+            patch.object(macos_app, "_APPKIT_AVAILABLE", True),
+            patch.object(macos_app, "_APPKIT", appkit),
+            caplog.at_level(logging.WARNING, logger="ytm_player.services.macos_app"),
+        ):
+            assert hide_dock_icon() is False
+        app.setActivationPolicy_.assert_called_once_with(1)
+        assert "refused" in caplog.text
+
+    def test_off_main_thread_does_not_touch_appkit(self) -> None:
+        appkit = MagicMock()
+        results: list[bool] = []
+        with (
+            patch.object(macos_app.sys, "platform", "darwin"),
+            patch.object(macos_app, "_APPKIT_AVAILABLE", True),
+            patch.object(macos_app, "_APPKIT", appkit),
+        ):
+            worker = threading.Thread(target=lambda: results.append(hide_dock_icon()))
+            worker.start()
+            worker.join()
+        assert results == [False]
+        appkit.NSApplication.sharedApplication.assert_not_called()
 
     def test_swallows_appkit_errors(self) -> None:
         appkit = MagicMock()

--- a/tests/test_services/test_macos_eventtap.py
+++ b/tests/test_services/test_macos_eventtap.py
@@ -62,7 +62,11 @@ class TestTapCallback:
         fake_appkit = SimpleNamespace(
             NSEvent=SimpleNamespace(eventWithCGEvent_=lambda _event: ns_event)
         )
-        fake_quartz = SimpleNamespace(NSSystemDefined=14)
+        fake_quartz = SimpleNamespace(
+            NSSystemDefined=14,
+            kCGEventTapDisabledByTimeout=0xFFFFFFFE,
+            kCGEventTapDisabledByUserInput=0xFFFFFFFF,
+        )
 
         with (
             patch("ytm_player.services.macos_eventtap.AppKit", fake_appkit),
@@ -72,6 +76,27 @@ class TestTapCallback:
 
         assert result is None
         await asyncio.wait_for(fired.wait(), timeout=1)
+
+    async def test_reenables_tap_after_timeout_disable(self) -> None:
+        svc = MacOSEventTapService()
+        svc._running = True
+        svc._loop = asyncio.get_running_loop()
+        svc._tap = object()
+
+        enabled_calls = []
+        fake_quartz = SimpleNamespace(
+            NSSystemDefined=14,
+            kCGEventTapDisabledByTimeout=0xFFFFFFFE,
+            kCGEventTapDisabledByUserInput=0xFFFFFFFF,
+            CGEventTapEnable=lambda tap, enabled: enabled_calls.append((tap, enabled)),
+        )
+        source_event = object()
+
+        with patch("ytm_player.services.macos_eventtap.Quartz", fake_quartz):
+            result = svc._tap_callback(None, 0xFFFFFFFE, source_event, None)
+
+        assert result is source_event
+        assert enabled_calls == [(svc._tap, True)]
 
     async def test_passthrough_when_not_mapped(self) -> None:
         svc = MacOSEventTapService()
@@ -85,7 +110,11 @@ class TestTapCallback:
         fake_appkit = SimpleNamespace(
             NSEvent=SimpleNamespace(eventWithCGEvent_=lambda _event: ns_event)
         )
-        fake_quartz = SimpleNamespace(NSSystemDefined=14)
+        fake_quartz = SimpleNamespace(
+            NSSystemDefined=14,
+            kCGEventTapDisabledByTimeout=0xFFFFFFFE,
+            kCGEventTapDisabledByUserInput=0xFFFFFFFF,
+        )
 
         with (
             patch("ytm_player.services.macos_eventtap.AppKit", fake_appkit),

--- a/tests/test_services/test_macos_media.py
+++ b/tests/test_services/test_macos_media.py
@@ -98,6 +98,29 @@ def _reset_fake_media_player() -> None:
     _FakeMediaPlayerModule._now = _FakeNowPlayingInfoCenter()
 
 
+class _FakeRunLoop:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def runMode_beforeDate_(self, _mode, _date) -> None:
+        self.calls += 1
+
+
+class _FakeFoundationModule:
+    NSDefaultRunLoopMode = "default"
+    _run_loop = _FakeRunLoop()
+
+    class NSRunLoop:
+        @staticmethod
+        def mainRunLoop():
+            return _FakeFoundationModule._run_loop
+
+    class NSDate:
+        @staticmethod
+        def date():
+            return object()
+
+
 class TestStart:
     async def test_noop_when_framework_missing(self, caplog) -> None:
         svc = MacOSMediaService()
@@ -155,6 +178,31 @@ class TestStart:
         finally:
             svc.stop()
             _dispatch._dispatch_context = None
+
+    async def test_pumps_cocoa_run_loop_until_stopped(self) -> None:
+        _reset_fake_media_player()
+        _FakeFoundationModule._run_loop = _FakeRunLoop()
+        svc = MacOSMediaService()
+
+        with (
+            patch("ytm_player.services.macos_media._MEDIA_PLAYER_AVAILABLE", True),
+            patch("ytm_player.services.macos_media._MP", _FakeMediaPlayerModule),
+            patch("ytm_player.services.macos_media._FOUNDATION", _FakeFoundationModule),
+        ):
+            await svc.start({}, asyncio.get_running_loop())
+            await asyncio.sleep(0)
+            task = svc._run_loop_task
+            assert task is not None
+            assert _FakeFoundationModule._run_loop.calls == 1
+
+            await svc.start({}, asyncio.get_running_loop())
+            assert svc._run_loop_task is task
+
+            calls_before_stop = _FakeFoundationModule._run_loop.calls
+            svc.stop()
+            await asyncio.sleep(0)
+            assert task.done()
+            assert _FakeFoundationModule._run_loop.calls == calls_before_stop
 
 
 class TestNowPlayingUpdates:

--- a/tests/test_services/test_macos_smoke.py
+++ b/tests/test_services/test_macos_smoke.py
@@ -1,0 +1,132 @@
+"""Real-framework smoke test for the macOS integrations (runs on macOS only).
+
+Every other macOS test mocks AppKit, Foundation and MediaPlayer. This module
+exercises the new code paths against the frameworks as installed, so a CI run
+on macos-latest shows they execute without raising and that what the code
+reports matches what the frameworks report back.
+
+What it proves: the process can be demoted to an accessory app and restored,
+the media service starts against the real MPRemoteCommandCenter, publishes
+metadata that MPNowPlayingInfoCenter reads back, services the main run loop
+alongside asyncio, and tears everything down. What it cannot prove: that the
+Dock tile, Control Center or the media keys behave as a user sees them. Those
+stay unverified until someone runs the branch on a desktop session.
+
+Deliberately NOT exercised: the media-key event tap. Creating a CGEventTap
+needs Input Monitoring / Accessibility permission and captures keyboard events
+system-wide; ``test_media_key_event_tap_is_not_exercised`` records that gap
+explicitly instead of pretending to cover it.
+
+Any framework that is missing on macOS is a hard failure here, not a skip:
+pyproject declares them for ``sys_platform == 'darwin'``, so absence means a
+packaging problem that must not pass as validated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import threading
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform != "darwin", reason="macOS frameworks only")
+
+_ACCESSORY = 1
+_SMOKE_TIMEOUT = 5.0
+
+
+def _framework(name: str) -> Any:
+    try:
+        return importlib.import_module(name)
+    except ImportError as exc:
+        pytest.fail(
+            f"{name} is not importable on macOS ({exc}); pyproject declares the pyobjc "
+            "frameworks for darwin, so this install cannot validate the macOS integration"
+        )
+
+
+class TestDockPolicySmoke:
+    def test_accessory_policy_is_applied_and_restored(self) -> None:
+        appkit = _framework("AppKit")
+        from ytm_player.services import macos_app
+        from ytm_player.services.macos_app import hide_dock_icon
+
+        assert macos_app._APPKIT_AVAILABLE, "macos_app did not pick up AppKit at import"
+        assert threading.current_thread() is threading.main_thread()
+        app = appkit.NSApplication.sharedApplication()
+        previous = app.activationPolicy()
+        try:
+            switched = hide_dock_icon()
+            actual = app.activationPolicy()
+            assert switched is True, (
+                f"AppKit refused the accessory activation policy on this host "
+                f"(policy now {actual}); Dock behaviour cannot be validated here"
+            )
+            assert actual == _ACCESSORY
+        finally:
+            restored = app.setActivationPolicy_(previous)
+            assert restored, f"could not restore activation policy {previous}"
+            assert app.activationPolicy() == previous
+
+
+class TestMediaServiceSmoke:
+    async def test_start_publish_pump_and_stop(self) -> None:
+        mp = _framework("MediaPlayer")
+        foundation = _framework("Foundation")
+        from ytm_player.services import macos_media
+        from ytm_player.services.macos_media import MacOSMediaService
+
+        assert macos_media._MEDIA_PLAYER_AVAILABLE, "macos_media did not pick up MediaPlayer"
+        assert macos_media._FOUNDATION is not None, "macos_media did not pick up Foundation"
+        assert threading.current_thread() is threading.main_thread()
+        assert foundation.NSRunLoop.mainRunLoop() is not None
+
+        service = MacOSMediaService()
+        center = mp.MPNowPlayingInfoCenter.defaultCenter()
+        loop = asyncio.get_running_loop()
+        try:
+            await asyncio.wait_for(service.start({}, loop), _SMOKE_TIMEOUT)
+            assert service._running is True
+            assert len(service._registered_targets) == 5, "not every remote command registered"
+            assert service._run_loop_task is not None, "run-loop pump was not started"
+
+            await asyncio.wait_for(
+                service.update_metadata("Smoke title", "Smoke artist", "Smoke album", 90_000_000),
+                _SMOKE_TIMEOUT,
+            )
+            published = center.nowPlayingInfo()
+            assert published is not None, "MPNowPlayingInfoCenter has no now-playing info"
+            assert published[macos_media._TITLE_KEY] == "Smoke title"
+            assert published[macos_media._ARTIST_KEY] == "Smoke artist"
+            assert float(published[macos_media._DURATION_KEY]) == 90.0
+
+            await asyncio.wait_for(service.update_playback_status("playing"), _SMOKE_TIMEOUT)
+            # Two pump intervals: the run-loop task must survive real
+            # runMode:beforeDate: calls without raising.
+            await asyncio.sleep(1.1)
+            assert service._run_loop_task is not None and not service._run_loop_task.done(), (
+                "run-loop pump stopped on its own — check the log for an exception"
+            )
+        finally:
+            service.stop()
+
+        assert service._running is False
+        assert service._run_loop_task is None
+        assert service._registered_targets == []
+        assert center.nowPlayingInfo() is None, "now-playing info not cleared on stop"
+
+
+def test_media_key_event_tap_is_not_exercised() -> None:
+    """Recorded gap, on purpose: no CGEventTap is created in this suite."""
+    quartz = _framework("Quartz")
+    # The constants the re-enable branch keys on exist in the real framework;
+    # the branch itself is covered with a fake tap in test_macos_eventtap.py.
+    assert hasattr(quartz, "kCGEventTapDisabledByTimeout")
+    assert hasattr(quartz, "kCGEventTapDisabledByUserInput")
+    pytest.skip(
+        "media-key event tap not exercised: creating a CGEventTap needs Input Monitoring / "
+        "Accessibility and captures keyboard events system-wide; media keys stay unverified"
+    )

--- a/tests/test_services/test_macos_smoke.py
+++ b/tests/test_services/test_macos_smoke.py
@@ -114,10 +114,17 @@ def test_media_service_start_publish_pump_and_stop() -> None:
     assert float(published[macos_media._DURATION_KEY]) == 90.0
 
     assert r["rate_after_playing"] == 1.0, "playback rate not published for 'playing'"
-    if r["state_playing_const"] is not None and r["state_after_playing"] is not None:
-        assert r["state_after_playing"] == r["state_playing_const"], (
-            "playback state not published for 'playing'"
-        )
+    assert r["state_playing_const"] is not None, (
+        "MPNowPlayingPlaybackStatePlaying is unavailable in this MediaPlayer; the playback "
+        "state cannot be validated here"
+    )
+    assert r["state_after_playing"] is not None, (
+        "MPNowPlayingInfoCenter.playbackState is unavailable here; the playback state "
+        "cannot be validated"
+    )
+    assert r["state_after_playing"] == r["state_playing_const"], (
+        "playback state not published for 'playing'"
+    )
 
     assert r["pump_alive_after_pumping"], (
         "run-loop pump stopped on its own — check the child's stderr for an exception"

--- a/tests/test_services/test_macos_smoke.py
+++ b/tests/test_services/test_macos_smoke.py
@@ -1,131 +1,138 @@
 """Real-framework smoke test for the macOS integrations (runs on macOS only).
 
-Every other macOS test mocks AppKit, Foundation and MediaPlayer. This module
-exercises the new code paths against the frameworks as installed, so a CI run
-on macos-latest shows they execute without raising and that what the code
-reports matches what the frameworks report back.
+Every other macOS test mocks AppKit, Foundation and MediaPlayer. On macOS
+this module exercises the new code paths against the frameworks as installed,
+each case in its own child process (``_macos_smoke_child.py``) with a
+wall-clock timeout enforced by killing the child: the framework calls are
+synchronous, so no in-process timeout could interrupt them, and a fresh
+process keeps AppKit on a main thread. Each child restores what it changed in
+``finally``; after a forced kill that cleanup has not run.
 
 What it proves: the process can be demoted to an accessory app and restored,
 the media service starts against the real MPRemoteCommandCenter, publishes
-metadata that MPNowPlayingInfoCenter reads back, services the main run loop
-alongside asyncio, and tears everything down. What it cannot prove: that the
-Dock tile, Control Center or the media keys behave as a user sees them. Those
-stay unverified until someone runs the branch on a desktop session.
+metadata and playback state that MPNowPlayingInfoCenter reads back, services
+the main run loop alongside asyncio, and tears down. What it cannot prove:
+that the Dock tile, Control Center or the media keys behave as a user sees
+them. Those stay unverified until someone runs the branch on a desktop.
 
 Deliberately NOT exercised: the media-key event tap. Creating a CGEventTap
 needs Input Monitoring / Accessibility permission and captures keyboard events
 system-wide; ``test_media_key_event_tap_is_not_exercised`` records that gap
-explicitly instead of pretending to cover it.
+as an explicit skip instead of pretending to cover it.
 
-Any framework that is missing on macOS is a hard failure here, not a skip:
-pyproject declares them for ``sys_platform == 'darwin'``, so absence means a
-packaging problem that must not pass as validated.
+A framework missing on macOS is a failure, not a skip: pyproject declares
+them for ``sys_platform == 'darwin'``, so absence means a packaging problem
+that must not pass as validated. A refused activation policy fails too; on a
+CI runner that warrants investigation, it is not by itself a regression.
 """
 
 from __future__ import annotations
 
-import asyncio
-import importlib
+import json
+import os
+import subprocess
 import sys
-import threading
+import time
+from pathlib import Path
 from typing import Any
 
 import pytest
 
-pytestmark = pytest.mark.skipif(sys.platform != "darwin", reason="macOS frameworks only")
-
+_CHILD = Path(__file__).with_name("_macos_smoke_child.py")
 _ACCESSORY = 1
-_SMOKE_TIMEOUT = 5.0
+_CASE_TIMEOUT = 30.0
+
+darwin_only = pytest.mark.skipif(sys.platform != "darwin", reason="macOS frameworks only")
 
 
-def _framework(name: str) -> Any:
+def _run_child(case: str, timeout: float = _CASE_TIMEOUT) -> dict[str, Any]:
+    """Run one smoke case in a child process; kill it if it exceeds *timeout*."""
     try:
-        return importlib.import_module(name)
-    except ImportError as exc:
+        proc = subprocess.run(
+            [sys.executable, str(_CHILD), case],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=os.environ,
+            cwd=_CHILD.parents[2],
+        )
+    except subprocess.TimeoutExpired:
         pytest.fail(
-            f"{name} is not importable on macOS ({exc}); pyproject declares the pyobjc "
-            "frameworks for darwin, so this install cannot validate the macOS integration"
+            f"{case}: child exceeded {timeout:.0f}s and was killed; the framework call "
+            "blocked and the child's cleanup did not run"
+        )
+    if proc.returncode == 2:
+        pytest.fail(
+            f"{case}: {proc.stderr.strip()} -- pyproject declares the pyobjc frameworks "
+            "for darwin, so this install cannot validate the macOS integration"
+        )
+    if proc.returncode != 0:
+        pytest.fail(f"{case}: child failed (exit {proc.returncode})\n{proc.stderr}")
+    return json.loads(proc.stdout)
+
+
+def test_blocking_child_is_killed_within_the_timeout() -> None:
+    """The bound is enforced by the parent, not by anything the child awaits."""
+    started = time.monotonic()
+    with pytest.raises(pytest.fail.Exception, match="exceeded 1s and was killed"):
+        _run_child("hang", timeout=1.0)
+    assert time.monotonic() - started < 5.0
+
+
+@darwin_only
+def test_accessory_policy_is_applied_and_restored() -> None:
+    r = _run_child("dock")
+
+    assert r["appkit_available"], "macos_app did not pick up AppKit at import"
+    assert r["main_thread"], "the child did not run on its main thread"
+    assert r["switched"] is True, (
+        f"AppKit refused the accessory activation policy on this host (policy after: "
+        f"{r['policy_after']}); investigate the runner before reading this as a regression"
+    )
+    assert r["policy_after"] == _ACCESSORY
+    assert r["restored"] is True, f"could not restore activation policy {r['previous']}"
+    assert r["policy_final"] == r["previous"]
+
+
+@darwin_only
+def test_media_service_start_publish_pump_and_stop() -> None:
+    from ytm_player.services import macos_media
+
+    r = _run_child("media")
+
+    assert r["media_player_available"], "macos_media did not pick up MediaPlayer"
+    assert r["foundation_available"], "macos_media did not pick up Foundation"
+    assert r["main_thread"] and r["main_run_loop"]
+    assert r["running"] is True
+    assert r["registered"] == 5, "not every remote command registered"
+    assert r["pump_started"], "run-loop pump was not started"
+
+    published = r["published"]
+    assert published is not None, "MPNowPlayingInfoCenter has no now-playing info"
+    assert published[macos_media._TITLE_KEY] == "Smoke title"
+    assert published[macos_media._ARTIST_KEY] == "Smoke artist"
+    assert float(published[macos_media._DURATION_KEY]) == 90.0
+
+    assert r["rate_after_playing"] == 1.0, "playback rate not published for 'playing'"
+    if r["state_playing_const"] is not None and r["state_after_playing"] is not None:
+        assert r["state_after_playing"] == r["state_playing_const"], (
+            "playback state not published for 'playing'"
         )
 
-
-class TestDockPolicySmoke:
-    def test_accessory_policy_is_applied_and_restored(self) -> None:
-        appkit = _framework("AppKit")
-        from ytm_player.services import macos_app
-        from ytm_player.services.macos_app import hide_dock_icon
-
-        assert macos_app._APPKIT_AVAILABLE, "macos_app did not pick up AppKit at import"
-        assert threading.current_thread() is threading.main_thread()
-        app = appkit.NSApplication.sharedApplication()
-        previous = app.activationPolicy()
-        try:
-            switched = hide_dock_icon()
-            actual = app.activationPolicy()
-            assert switched is True, (
-                f"AppKit refused the accessory activation policy on this host "
-                f"(policy now {actual}); Dock behaviour cannot be validated here"
-            )
-            assert actual == _ACCESSORY
-        finally:
-            restored = app.setActivationPolicy_(previous)
-            assert restored, f"could not restore activation policy {previous}"
-            assert app.activationPolicy() == previous
+    assert r["pump_alive_after_pumping"], (
+        "run-loop pump stopped on its own — check the child's stderr for an exception"
+    )
+    assert r["pump_finished_after_stop"], "run-loop pump did not finish after stop()"
+    assert r["running_after_stop"] is False
+    assert r["targets_after_stop"] == 0
+    assert r["info_after_stop"] is False, "now-playing info not cleared on stop"
 
 
-class TestMediaServiceSmoke:
-    async def test_start_publish_pump_and_stop(self) -> None:
-        mp = _framework("MediaPlayer")
-        foundation = _framework("Foundation")
-        from ytm_player.services import macos_media
-        from ytm_player.services.macos_media import MacOSMediaService
-
-        assert macos_media._MEDIA_PLAYER_AVAILABLE, "macos_media did not pick up MediaPlayer"
-        assert macos_media._FOUNDATION is not None, "macos_media did not pick up Foundation"
-        assert threading.current_thread() is threading.main_thread()
-        assert foundation.NSRunLoop.mainRunLoop() is not None
-
-        service = MacOSMediaService()
-        center = mp.MPNowPlayingInfoCenter.defaultCenter()
-        loop = asyncio.get_running_loop()
-        try:
-            await asyncio.wait_for(service.start({}, loop), _SMOKE_TIMEOUT)
-            assert service._running is True
-            assert len(service._registered_targets) == 5, "not every remote command registered"
-            assert service._run_loop_task is not None, "run-loop pump was not started"
-
-            await asyncio.wait_for(
-                service.update_metadata("Smoke title", "Smoke artist", "Smoke album", 90_000_000),
-                _SMOKE_TIMEOUT,
-            )
-            published = center.nowPlayingInfo()
-            assert published is not None, "MPNowPlayingInfoCenter has no now-playing info"
-            assert published[macos_media._TITLE_KEY] == "Smoke title"
-            assert published[macos_media._ARTIST_KEY] == "Smoke artist"
-            assert float(published[macos_media._DURATION_KEY]) == 90.0
-
-            await asyncio.wait_for(service.update_playback_status("playing"), _SMOKE_TIMEOUT)
-            # Two pump intervals: the run-loop task must survive real
-            # runMode:beforeDate: calls without raising.
-            await asyncio.sleep(1.1)
-            assert service._run_loop_task is not None and not service._run_loop_task.done(), (
-                "run-loop pump stopped on its own — check the log for an exception"
-            )
-        finally:
-            service.stop()
-
-        assert service._running is False
-        assert service._run_loop_task is None
-        assert service._registered_targets == []
-        assert center.nowPlayingInfo() is None, "now-playing info not cleared on stop"
-
-
+@darwin_only
 def test_media_key_event_tap_is_not_exercised() -> None:
     """Recorded gap, on purpose: no CGEventTap is created in this suite."""
-    quartz = _framework("Quartz")
-    # The constants the re-enable branch keys on exist in the real framework;
-    # the branch itself is covered with a fake tap in test_macos_eventtap.py.
-    assert hasattr(quartz, "kCGEventTapDisabledByTimeout")
-    assert hasattr(quartz, "kCGEventTapDisabledByUserInput")
+    r = _run_child("tap_constants")
+    assert r["has_timeout_const"] and r["has_user_input_const"]
     pytest.skip(
         "media-key event tap not exercised: creating a CGEventTap needs Input Monitoring / "
         "Accessibility and captures keyboard events system-wide; media keys stay unverified"

--- a/tests/test_services/test_player.py
+++ b/tests/test_services/test_player.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -832,3 +833,77 @@ class TestErrorPayload:
         await player.stop()
 
         assert player._current_attempt is None
+
+
+class TestDockPolicyDispatch:
+    """The Dock policy reaches AppKit on the main thread only (#128 follow-up)."""
+
+    def test_startup_applies_the_policy_directly_on_the_main_thread(self, player):
+        seen: list[threading.Thread] = []
+        with patch(
+            "ytm_player.services.player.hide_dock_icon",
+            side_effect=lambda: seen.append(threading.current_thread()) or True,
+        ):
+            player._init_mpv()
+
+        assert seen == [threading.main_thread()]
+
+    async def test_worker_thread_recovery_is_handed_to_the_main_thread_loop(self, player):
+        seen: list[threading.Thread] = []
+        worker: list[threading.Thread] = []
+        player.set_event_loop(asyncio.get_running_loop())
+
+        def on_worker():
+            worker.append(threading.current_thread())
+            player._apply_dock_policy()
+
+        with patch(
+            "ytm_player.services.player.hide_dock_icon",
+            side_effect=lambda: seen.append(threading.current_thread()) or True,
+        ):
+            await asyncio.to_thread(on_worker)
+            await asyncio.sleep(0)  # the scheduled call runs on the loop
+
+        assert worker[0] is not threading.main_thread()
+        assert seen == [threading.main_thread()]  # ran on the loop's thread, not the worker
+
+    async def test_worker_thread_without_a_loop_skips_the_policy(self, player):
+        assert player._loop is None
+        with patch("ytm_player.services.player.hide_dock_icon") as hide:
+            await asyncio.to_thread(player._apply_dock_policy)
+            await asyncio.sleep(0)
+
+        hide.assert_not_called()
+
+    async def test_worker_thread_with_a_loop_off_the_main_thread_skips_the_policy(self, player):
+        player.set_event_loop(asyncio.get_running_loop())
+        player._loop_thread = threading.Thread()  # a loop that isn't on the main thread
+        with patch("ytm_player.services.player.hide_dock_icon") as hide:
+            await asyncio.to_thread(player._apply_dock_policy)
+            await asyncio.sleep(0)
+
+        hide.assert_not_called()
+
+    async def test_mpv_recovery_from_the_play_worker_reaches_the_main_thread(self, player):
+        """End to end: _play_sync's ShutdownError → _try_recover → _init_mpv, on a worker."""
+        from ytm_player.services.player import mpv as _mpv
+
+        seen: list[threading.Thread] = []
+        player.set_event_loop(asyncio.get_running_loop())
+        calls = {"n": 0}
+
+        def flaky_play(url):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise _mpv.ShutdownError("simulated crash")
+
+        player._mpv.play.side_effect = flaky_play
+        with patch(
+            "ytm_player.services.player.hide_dock_icon",
+            side_effect=lambda: seen.append(threading.current_thread()) or True,
+        ):
+            await player.play("http://stream", {"video_id": "abc"})
+            await asyncio.sleep(0)
+
+        assert calls["n"] == 2  # recovered and replayed
+        assert seen == [threading.main_thread()]


### PR DESCRIPTION
Draft. Combines #141 (@wgordon17), #131 (@alvaro0x404) and #128 (@aksholokhov), rebased on current master with their commits intact, plus maintainer commits: changelog entries for all three, the Dock policy applied on the main thread after a worker-thread mpv recovery and reporting success only when AppKit does, and a real-framework smoke test that runs on macOS CI.

Purpose of this PR is the macOS CI run. The smoke test runs each case in a child process the parent can kill, applies and restores the accessory policy, and drives the media service against the real MediaPlayer frameworks, reading Now Playing metadata and playback state back. It does not create an event tap. Dock, Control Center and media-key behaviour as a user sees it is not verified by CI; I can't test on my own Mac right now.

Not for merging as is. The three fixes will be merged through their own PRs.
