### PR TITLE
feat(history): add All view and show unfiltered YT Music history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+**Changes**
+
+- **Recently Played: All / Local / YT Music tabs** (#115) — the YT Music tab now shows your account's complete play history instead of hiding every track ever played in this app, and a new All tab (the default) shows local history first, followed by additional account history, one row per track. A line under the tabs says what each shows, and the footer says when a source couldn't be loaded. A play the account accepts appears on the YT Music and All tabs right away. Thanks @Villoh for the tabs and the discussion.
+
 **Fixes**
 
 - **Double-clicking a sidebar playlist loaded it three times** — one double-click fired two single-click selections plus the double-click, starting three concurrent playlist fetches. It now fires exactly one selection and one double-click.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,16 @@ sync_history_to_ytmusic = true  # report TUI plays back to your YT Music account
 
 > `sync_history_to_ytmusic` reports tracks you play in the TUI back to your YouTube Music account history (via ytmusicapi's `add_history_item`), so they show up in your history and feed recommendations like any other client. It uses `history_min_listen_seconds` as the reporting threshold. Set to `false` to keep TUI listening off your account.
 
+#### Recently Played tabs
+
+`g r` opens Recently Played with three tabs; a line under the tab row says what the active one shows.
+
+- **All** (default) — local history first, followed by additional account history. One row per track: a track played both here and elsewhere keeps its local position and time, with artist, album and artwork details filled in from the account row. It is two groups, not one timeline — the account feed only says roughly when a track was played, so a phone play from an hour ago can sit below an older play from this app. Up to 100 local rows plus up to 100 further account rows.
+- **Local** — tracks played in this app, most recent first, up to 100.
+- **YT Music** — your account's complete play history from any device, in YouTube Music's order, up to 100. Needs a signed-in session.
+
+If one source can't be loaded, All shows the other and says so in the footer. Re-selecting the active tab refreshes it; refreshing All refetches both sources. A play the account accepts (with `sync_history_to_ytmusic` on) appears on the YT Music and All tabs right away.
+
 ### `[cache]`
 
 ```toml

--- a/src/ytm_player/app/_app.py
+++ b/src/ytm_player/app/_app.py
@@ -281,6 +281,9 @@ class YTMPlayerApp(
         # we don't refetch on every visit, and is optimistically prepended to
         # when a play is reported. None = not fetched yet this session.
         self._ytm_history: list[dict] | None = None
+        # Plays the account accepted while _ytm_history was None; merged in
+        # ahead of the next fetched feed (see _add_to_ytm_history_cache).
+        self._ytm_history_pending: list[dict] = []
         # Makes the generation check + mpv play command atomic.
         self._play_lock = asyncio.Lock()
 

--- a/src/ytm_player/app/_app.py
+++ b/src/ytm_player/app/_app.py
@@ -281,9 +281,12 @@ class YTMPlayerApp(
         # we don't refetch on every visit, and is optimistically prepended to
         # when a play is reported. None = not fetched yet this session.
         self._ytm_history: list[dict] | None = None
-        # Plays the account accepted while _ytm_history was None; merged in
-        # ahead of the next fetched feed (see _add_to_ytm_history_cache).
-        self._ytm_history_pending: list[dict] = []
+        # Plays the account accepted while _ytm_history was None, newest
+        # first, each with a sequence number so the next fetch can tell
+        # whether the play came before or after the feed it received (see
+        # _add_to_ytm_history_cache).
+        self._ytm_history_pending: list[tuple[int, dict]] = []
+        self._ytm_history_pending_seq = 0
         # Makes the generation check + mpv play command atomic.
         self._play_lock = asyncio.Lock()
 

--- a/src/ytm_player/app/_base.py
+++ b/src/ytm_player/app/_base.py
@@ -114,7 +114,8 @@ if TYPE_CHECKING:
         _ytm_reported_generation: int
         _local_history_claim: _LocalHistoryClaim | None
         _ytm_history: list[dict] | None
-        _ytm_history_pending: list[dict]
+        _ytm_history_pending: list[tuple[int, dict]]
+        _ytm_history_pending_seq: int
         _play_lock: asyncio.Lock
 
         # ── Pending resume from prior session ──────────────────────────

--- a/src/ytm_player/app/_base.py
+++ b/src/ytm_player/app/_base.py
@@ -114,6 +114,7 @@ if TYPE_CHECKING:
         _ytm_reported_generation: int
         _local_history_claim: _LocalHistoryClaim | None
         _ytm_history: list[dict] | None
+        _ytm_history_pending: list[dict]
         _play_lock: asyncio.Lock
 
         # ── Pending resume from prior session ──────────────────────────

--- a/src/ytm_player/app/_playback.py
+++ b/src/ytm_player/app/_playback.py
@@ -17,6 +17,10 @@ from ytm_player.utils.formatting import get_video_id, normalize_tracks
 logger = logging.getLogger(__name__)
 
 _MAX_CONSECUTIVE_FAILURES = 5
+# Plays the account accepted while no account history was cached; the next
+# fetch merges them in. Bounded so a session that never opens the page
+# cannot grow it without limit.
+_YTM_PENDING_MAX = 100
 
 # Poll player.position with a timer instead of relying on UI position events:
 # timers keep firing when the terminal window loses focus, while position stays
@@ -809,14 +813,12 @@ class PlaybackMixin(YTMHostBase):
                 # duplicate from a blind direct log.
                 owned.pending_seconds = listened
             else:
-                play_id = await self.history.log_play(
+                await self.history.log_play(
                     track=track,
                     listened_seconds=listened,
                     source="tui",
                     min_listen_seconds=self._history_min_listen_seconds(),
                 )
-                if play_id is not None:
-                    self._drop_from_ytm_history_cache(video_id)
         except Exception:
             logger.exception("Failed to log play history")
 
@@ -902,8 +904,6 @@ class PlaybackMixin(YTMHostBase):
         claim.row_id = play_id
         if play_id is None:
             return
-        # The play is now local history; keep the YT Music tab disjoint.
-        self._drop_from_ytm_history_cache(claim.video_id)
         # Finalize may have stashed the final duration while the insert was
         # in flight. No await sits between publishing row_id above and
         # reading pending_seconds here, so a finalize either already saw
@@ -934,22 +934,27 @@ class PlaybackMixin(YTMHostBase):
         if isinstance(page, RecentlyPlayedPage):
             page.optimistic_add(_TAB_LOCAL, track)
 
-    def _drop_from_ytm_history_cache(self, video_id: str) -> None:
-        """Evict a just-logged local play from the cached YT Music tab.
+    def _add_to_ytm_history_cache(self, track: dict) -> None:
+        """Reflect a play the account just accepted in the cached account history.
 
-        The YT Music tab shows online-only plays: once a track enters the
-        local history, a fresh ``get_history()`` fetch would filter it out,
-        so the populated app-level cache must drop it too — otherwise the
-        tabs stop being disjoint until the next refetch. Re-renders the tab
-        live if it is showing.
+        Runs only after ``add_history_item`` succeeded, so the YT Music and
+        All tabs agree with the account. With a feed cached, the play moves
+        to the top. With none cached (first visit still pending, or a
+        refresh in flight) it is parked in ``_ytm_history_pending`` and the
+        next fetch puts it ahead of the feed it received — a fetch that
+        started before this report cannot hide it. Re-renders the page
+        when the YT Music or All tab is showing.
         """
+        video_id = get_video_id(track)
+        if not video_id:
+            return
         cache = self._ytm_history
-        if cache is None or not video_id:
+        if cache is None:
+            pending = self._ytm_history_pending
+            pending[:] = [dict(track)] + [t for t in pending if get_video_id(t) != video_id]
+            del pending[_YTM_PENDING_MAX:]
             return
-        pruned = [t for t in cache if get_video_id(t) != video_id]
-        if len(pruned) == len(cache):
-            return
-        self._ytm_history = pruned
+        self._ytm_history = [dict(track)] + [t for t in cache if get_video_id(t) != video_id]
 
         from ytm_player.ui.pages.recently_played import _TAB_YTM, RecentlyPlayedPage
 
@@ -1013,24 +1018,25 @@ class PlaybackMixin(YTMHostBase):
             )
             return
         self.run_worker(
-            self._push_ytm_history_report(video_id, generation),
+            self._push_ytm_history_report(track, video_id, generation),
             group="ytm-history-report",
         )
 
-    async def _push_ytm_history_report(self, video_id: str, generation: int) -> None:
+    async def _push_ytm_history_report(self, track: dict, video_id: str, generation: int) -> None:
         """Report the play to the account history (best-effort).
 
         ``add_history_item`` returns False on any failure (expired auth,
         missing playbackTracking, non-204) without raising — marking the
-        play reported on failure would suppress the retry on the next poll.
-        The YT Music tab deliberately does NOT reflect this play: it shows
-        online-only plays and filters TUI plays out of the account feed.
+        play reported on failure would suppress the retry on the next poll,
+        and the cached account history is only updated once the account
+        actually accepted the play.
         """
         if not self.ytmusic:
             return
         if not await self.ytmusic.add_history_item(video_id):
             return
         self._ytm_reported_generation = generation
+        self._add_to_ytm_history_cache(track)
 
     # ── Like toggle ──────────────────────────────────────────────────
 

--- a/src/ytm_player/app/_playback.py
+++ b/src/ytm_player/app/_playback.py
@@ -940,18 +940,22 @@ class PlaybackMixin(YTMHostBase):
         Runs only after ``add_history_item`` succeeded, so the YT Music and
         All tabs agree with the account. With a feed cached, the play moves
         to the top. With none cached (first visit still pending, or a
-        refresh in flight) it is parked in ``_ytm_history_pending`` and the
-        next fetch puts it ahead of the feed it received — a fetch that
-        started before this report cannot hide it. Re-renders the page
-        when the YT Music or All tab is showing.
+        refresh in flight) it is parked in ``_ytm_history_pending`` with a
+        sequence number, so the next fetch can tell whether the play came
+        before or after the feed it received (see the page's
+        ``_merge_pending_account_plays``). Re-renders the page when the YT
+        Music or All tab is showing.
         """
         video_id = get_video_id(track)
         if not video_id:
             return
         cache = self._ytm_history
         if cache is None:
+            self._ytm_history_pending_seq += 1
             pending = self._ytm_history_pending
-            pending[:] = [dict(track)] + [t for t in pending if get_video_id(t) != video_id]
+            pending[:] = [(self._ytm_history_pending_seq, dict(track))] + [
+                entry for entry in pending if get_video_id(entry[1]) != video_id
+            ]
             del pending[_YTM_PENDING_MAX:]
             return
         self._ytm_history = [dict(track)] + [t for t in cache if get_video_id(t) != video_id]

--- a/src/ytm_player/ui/pages/recently_played.py
+++ b/src/ytm_player/ui/pages/recently_played.py
@@ -74,6 +74,21 @@ _TAB_DESCRIPTIONS = {
 _MAX_TRACKS = 100
 
 
+def _enrich(track: dict, extra: dict) -> dict:
+    """A copy of *track* with the fields it lacks filled in from *extra*.
+
+    A field counts as lacking when it is absent, ``None`` or ``""``; the
+    local row's own values, ``played_at`` included, are never replaced, and
+    an empty value in *extra* never replaces anything either.
+    """
+    merged = dict(track)
+    for key, value in extra.items():
+        if value in (None, "") or track.get(key) not in (None, ""):
+            continue
+        merged[key] = value
+    return merged
+
+
 def _compose_all(local: list[dict], account: list[dict]) -> list[dict]:
     """Local rows first, in their own order, then account-only rows in server order.
 
@@ -97,8 +112,7 @@ def _compose_all(local: list[dict], account: list[dict]) -> list[dict]:
         seen.add(vid)
         extra = by_id.get(vid)
         if extra is not None:
-            missing = {k: v for k, v in extra.items() if track.get(k) in (None, "")}
-            track = {**missing, **track}
+            track = _enrich(track, extra)
         rows.append(track)
     account_only = [track for vid, track in by_id.items() if vid not in seen]
     return rows + account_only[:_MAX_TRACKS]
@@ -133,7 +147,7 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
     }
     .recent-header {
         height: auto;
-        max-height: 4;
+        max-height: 5;
         padding: 1 2;
         background: $surface;
     }
@@ -149,7 +163,7 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
         color: $primary;
     }
     .recent-tab-desc {
-        height: 1;
+        height: auto;
         color: $text-muted;
     }
     .recent-tab-sep {
@@ -191,7 +205,8 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
         background: $primary 30%;
     }
     .recent-footer {
-        height: 1;
+        height: auto;
+        max-height: 2;
         padding: 0 2;
         color: $text-muted;
         dock: bottom;
@@ -331,9 +346,8 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
 
         The cache holds the whole normalized feed, unfiltered; views apply
         their own limits. Plays the account accepted while no feed was
-        cached (see ``_add_to_ytm_history_cache`` on the app) are put ahead
-        of the fetched feed, so a fetch that started before such a report
-        cannot hide it.
+        cached (see ``_add_to_ytm_history_cache`` on the app) are folded
+        into the fetched feed by ``_merge_pending_account_plays``.
         """
         self._ytm_auth_required = False
         self._ytm_load_failed = False
@@ -341,6 +355,9 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
         if not ytmusic:
             self._ytm_auth_required = True
             return
+        # Reports accepted from here on post-date the feed we are about to
+        # receive; the sequence number tells them apart from earlier ones.
+        fetch_seq = self._pending_account_seq()
         # ``get_history`` requires auth; the service logs and returns None on
         # any failure (expired session, network, server error) so we can tell
         # a genuine empty history from an error.
@@ -348,14 +365,35 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
         if raw is None:
             self._ytm_load_failed = True
             return
-        tracks = normalize_tracks(raw)
-        pending = self._take_pending_account_plays()
-        if pending:
-            ids = {get_video_id(t) for t in pending}
-            tracks = pending + [t for t in tracks if get_video_id(t) not in ids]
-        self._set_cache(_TAB_YTM, tracks)
+        self._set_cache(
+            _TAB_YTM, self._merge_pending_account_plays(normalize_tracks(raw), fetch_seq)
+        )
 
-    def _take_pending_account_plays(self) -> list[dict]:
+    def _pending_account_seq(self) -> int:
+        """The sequence number of the latest pending accepted play (0 = none yet)."""
+        seq = getattr(self.app, "_ytm_history_pending_seq", 0)
+        return seq if isinstance(seq, int) else 0
+
+    def _merge_pending_account_plays(self, feed: list[dict], fetch_seq: int) -> list[dict]:
+        """Fold the pending accepted plays into *feed*, consuming them.
+
+        A play accepted after the fetch started (sequence number above
+        *fetch_seq*) post-dates the feed, so it goes ahead of it even when
+        the feed already lists the track. A play accepted before the fetch
+        started is already reflected in the feed: its server position
+        stands. Only when the feed does not list such a play yet does it go
+        ahead of the feed, behind the newer plays.
+        """
+        pending = self._take_pending_account_plays()
+        if not pending:
+            return feed
+        feed_ids = {get_video_id(t) for t in feed}
+        ahead = [t for seq, t in pending if seq > fetch_seq]
+        ahead += [t for seq, t in pending if seq <= fetch_seq and get_video_id(t) not in feed_ids]
+        ahead_ids = {get_video_id(t) for t in ahead}
+        return ahead + [t for t in feed if get_video_id(t) not in ahead_ids]
+
+    def _take_pending_account_plays(self) -> list[tuple[int, dict]]:
         pending = getattr(self.app, "_ytm_history_pending", None)
         if not isinstance(pending, list) or not pending:
             return []
@@ -526,15 +564,19 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
             return f"{count} recently played tracks (local)"
         if self._active_tab == _TAB_YTM:
             return f"{count} recently played tracks (YT Music)"
-        text = f"{count} tracks — local history first, then additional account history"
-        # Partial results are said out loud: a missing source is not an empty one.
+        # Partial results are said out loud, and first: a missing source is
+        # not an empty one, and the notice must survive a narrow terminal.
         if self._load_failed:
-            text += " — local history couldn't be loaded; showing YT Music only"
+            notice = "Local history couldn't be loaded; showing YT Music history only"
         elif self._ytm_auth_required:
-            text += " — sign in to YT Music to include your account history"
+            notice = (
+                "Sign in to YT Music to include your account history; showing local history only"
+            )
         elif self._ytm_load_failed:
-            text += " — YT Music history couldn't be loaded; showing local only"
-        return text
+            notice = "YT Music history couldn't be loaded; showing local history only"
+        else:
+            return f"{count} tracks — local history first, then additional account history"
+        return f"{notice} — {count} tracks"
 
     def get_nav_state(self) -> dict[str, Any]:
         """Return state to preserve when navigating away."""

--- a/src/ytm_player/ui/pages/recently_played.py
+++ b/src/ytm_player/ui/pages/recently_played.py
@@ -1,14 +1,22 @@
 """Recently Played page.
 
-Two tabs:
+Three tabs:
+
+- **All** (default) — local history first, followed by additional account
+  history. One row per track: a track played both here and elsewhere keeps
+  its local position and time, with details the local row lacks filled in
+  from the account row. Two groups, not one timeline — the account feed only
+  says roughly when a track was played.
 - **Local** — play history from the local SQLite database (everything played
-  inside this app).
-- **YT Music** — server-side play history from the account, via the
-  unofficial ytmusicapi ``get_history()``. Requires authentication.
+  inside this app), most recent first.
+- **YT Music** — the account's play history from any device, via the
+  unofficial ytmusicapi ``get_history()``, in the server's order. Requires
+  authentication.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import sqlite3
 from typing import TYPE_CHECKING, Any, cast
@@ -43,19 +51,61 @@ _HISTORY_LOAD_FAILED_MSG = (
 _YTM_AUTH_REQUIRED_MSG = "Sign in to YT Music to see your account play history."
 _YTM_LOAD_FAILED_MSG = "Couldn't load YT Music history. Check the log for details."
 
-# Tab indices.
-_TAB_LOCAL = 0
-_TAB_YTM = 1
+# Tab indices, in display order.
+_TAB_ALL = 0
+_TAB_LOCAL = 1
+_TAB_YTM = 2
+_TABS = (_TAB_ALL, _TAB_LOCAL, _TAB_YTM)
+_DEFAULT_TAB = _TAB_ALL
+_TAB_IDS = {_TAB_ALL: "recent-tab-all", _TAB_LOCAL: "recent-tab-local", _TAB_YTM: "recent-tab-ytm"}
+# One line under the tab row saying what the active tab shows.
+_TAB_DESCRIPTIONS = {
+    _TAB_ALL: "Local history first, followed by additional account history — grouped, not one timeline",
+    _TAB_LOCAL: "Tracks played in this app, most recent first",
+    _TAB_YTM: "Your account's play history from any device, in YouTube Music's order",
+}
 
-# Cap the number of tracks rendered per tab. The local history query already
-# limits to 100 (rendering thousands of rows overloads the TUI); the YT Music
-# ``get_history()`` endpoint returns ~200 rows and isn't paginated, so we slice
-# it to the same 100 to keep both tabs snappy.
+# Cap the number of tracks rendered PER SOURCE. The local history query
+# already limits to 100 (rendering thousands of rows overloads the TUI); the
+# YT Music ``get_history()`` endpoint returns ~200 rows and isn't paginated.
+# The account cache keeps the whole normalized feed; each view applies the
+# cap when it derives its rows, so All shows up to 100 local rows plus up to
+# 100 further account rows.
 _MAX_TRACKS = 100
 
 
+def _compose_all(local: list[dict], account: list[dict]) -> list[dict]:
+    """Local rows first, in their own order, then account-only rows in server order.
+
+    One row per video ID. A track in both keeps the local row -- its position
+    and ``played_at`` -- with the fields the local row lacks (artist and album
+    IDs, thumbnail) filled in from the account row. Deduplication happens
+    before the account-only cap, so that cap never counts rows the local
+    block already shows.
+    """
+    by_id: dict[str, dict] = {}
+    for track in account:
+        vid = get_video_id(track)
+        if vid and vid not in by_id:
+            by_id[vid] = track
+    rows: list[dict] = []
+    seen: set[str] = set()
+    for track in local[:_MAX_TRACKS]:
+        vid = get_video_id(track)
+        if not vid or vid in seen:
+            continue
+        seen.add(vid)
+        extra = by_id.get(vid)
+        if extra is not None:
+            missing = {k: v for k, v in extra.items() if track.get(k) in (None, "")}
+            track = {**missing, **track}
+        rows.append(track)
+    account_only = [track for vid, track in by_id.items() if vid not in seen]
+    return rows + account_only[:_MAX_TRACKS]
+
+
 class RecentTab(Static):
-    """A focusable tab label (Local / YT Music).
+    """A focusable tab label (All / Local / YT Music).
 
     Made focusable so the app-wide ``Tab`` / ``Shift+Tab`` section traversal
     lands on each label in turn; ``Enter`` then switches to it (see
@@ -83,7 +133,7 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
     }
     .recent-header {
         height: auto;
-        max-height: 3;
+        max-height: 4;
         padding: 1 2;
         background: $surface;
     }
@@ -97,6 +147,10 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
     .recent-header-title {
         text-style: bold;
         color: $primary;
+    }
+    .recent-tab-desc {
+        height: 1;
+        color: $text-muted;
     }
     .recent-tab-sep {
         width: auto;
@@ -159,12 +213,12 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
         self,
         *,
         cursor_row: int | None = None,
-        active_tab: int = _TAB_LOCAL,
+        active_tab: int = _DEFAULT_TAB,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self._restore_cursor_row = cursor_row
-        self._active_tab = active_tab if active_tab in (_TAB_LOCAL, _TAB_YTM) else _TAB_LOCAL
+        self._active_tab = active_tab if active_tab in _TABS else _DEFAULT_TAB
         # Set when a loader catches an expected disk-side / network
         # failure so ``_display_tracks`` can render the failure message
         # instead of the genuine empty-state copy.
@@ -173,7 +227,8 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
         # or genuinely empty account history.
         self._ytm_auth_required = False
         self._ytm_load_failed = False
-        # Per-tab track cache so switching tabs doesn't refetch every time.
+        # Per-page cache for the Local tab. The account feed is cached at the
+        # app level (see _get_cache); All is derived from both, never cached.
         self._tab_cache: dict[int, list[dict]] = {}
 
     def compose(self) -> ComposeResult:
@@ -181,11 +236,17 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
             with Horizontal(classes="recent-header-row"):
                 yield Label("Recently Played", classes="recent-header-title")
                 yield Static("│", classes="recent-tab-sep")
-                local_cls = "recent-tab active" if self._active_tab == _TAB_LOCAL else "recent-tab"
-                ytm_cls = "recent-tab active" if self._active_tab == _TAB_YTM else "recent-tab"
-                yield RecentTab("Local", _TAB_LOCAL, id="recent-tab-local", classes=local_cls)
-                yield RecentTab("YT Music", _TAB_YTM, id="recent-tab-ytm", classes=ytm_cls)
+                for index, label in (
+                    (_TAB_ALL, "All"),
+                    (_TAB_LOCAL, "Local"),
+                    (_TAB_YTM, "YT Music"),
+                ):
+                    cls = "recent-tab active" if self._active_tab == index else "recent-tab"
+                    yield RecentTab(label, index, id=_TAB_IDS[index], classes=cls)
                 yield Static("[▶ Start Radio]", id="start-radio-btn", markup=True)
+            yield Static(
+                _TAB_DESCRIPTIONS[self._active_tab], id="recent-tab-desc", classes="recent-tab-desc"
+            )
         yield Label("Loading history...", id="recent-loading", classes="recent-loading")
         yield TrackTable(show_album=False, id="recent-table")
         yield Static("", id="recent-footer", classes="recent-footer")
@@ -197,15 +258,18 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
 
     def _load_active_tab(self) -> None:
         """Kick off the loader worker for the currently active tab."""
-        if self._active_tab == _TAB_YTM:
-            self.run_worker(self._load_ytm_history(), group="recent-load", exclusive=True)
-        else:
-            self.run_worker(self._load_history(), group="recent-load", exclusive=True)
+        loaders = {
+            _TAB_ALL: self._load_all,
+            _TAB_LOCAL: self._load_history,
+            _TAB_YTM: self._load_ytm_history,
+        }
+        self.run_worker(loaders[self._active_tab](), group="recent-load", exclusive=True)
 
-    # ── Per-tab cache ────────────────────────────────────────────────
-    # Local history lives in a per-page dict (cheap SQLite read). The YT
-    # Music history is cached at the app level so it survives page navigation
-    # (no refetch per visit).
+    # ── Source caches ────────────────────────────────────────────────
+    # The Local cache is per-page (cheap SQLite reads). The account feed is
+    # cached at the app level so it survives page navigation and can be
+    # updated by playback reporting while the page is closed. All has no
+    # cache of its own: it is derived from the two sources on every render.
 
     def _get_cache(self, index: int) -> list[dict] | None:
         if index == _TAB_YTM:
@@ -219,25 +283,35 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
             self._tab_cache[index] = tracks
 
     def _clear_cache(self, index: int) -> None:
-        if index == _TAB_YTM:
+        if index == _TAB_ALL:
+            self._clear_cache(_TAB_LOCAL)
+            self._clear_cache(_TAB_YTM)
+        elif index == _TAB_YTM:
             self.app._ytm_history = None  # type: ignore[attr-defined]
         else:
             self._tab_cache.pop(index, None)
 
-    async def _load_history(self) -> None:
-        """Load the local SQLite play history (Local tab)."""
+    def _sources_cached(self, index: int) -> bool:
+        if index == _TAB_ALL:
+            return self._get_cache(_TAB_LOCAL) is not None and self._get_cache(_TAB_YTM) is not None
+        return self._get_cache(index) is not None
+
+    def _rows_for(self, index: int) -> list[dict]:
+        """The rows a view shows, derived from the source caches with the view's limits."""
+        if index == _TAB_ALL:
+            return _compose_all(self._get_cache(_TAB_LOCAL) or [], self._get_cache(_TAB_YTM) or [])
+        return (self._get_cache(index) or [])[:_MAX_TRACKS]
+
+    # ── Loaders ──────────────────────────────────────────────────────
+
+    async def _fetch_local(self) -> None:
+        """Fill the Local cache from SQLite. Sets ``_load_failed``; renders nothing."""
         history = self.app.history  # type: ignore[attr-defined]
         if not history:
-            self.query_one("#recent-loading", Label).update("History not available.")
+            self._load_failed = True
             return
-
         try:
             tracks = await history.get_recently_played(limit=_MAX_TRACKS)
-            self._load_failed = False
-            # Cache only successful loads: a failure cached as [] would show
-            # "No play history yet" with no retry until remount (the YTM
-            # loader has the same success-only asymmetry).
-            self._set_cache(_TAB_LOCAL, tracks)
         except (OSError, sqlite3.Error):
             # Local DB failure: file unreadable, disk full, DB locked,
             # schema mismatch, corrupt page, etc. Programming errors
@@ -245,127 +319,145 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
             # must propagate so bugs surface in development per the
             # error-handling architecture in CLAUDE.md.
             logger.exception("Failed to load play history")
-            tracks = []
             self._load_failed = True
+            return
+        self._load_failed = False
+        # Cache only successful loads: a failure cached as [] would show
+        # "No play history yet" with no retry until remount.
+        self._set_cache(_TAB_LOCAL, tracks)
 
-        if self._active_tab == _TAB_LOCAL:
-            self._display_tracks(tracks)
+    async def _fetch_ytm(self) -> None:
+        """Fill the app-level account cache from ``get_history()``; renders nothing.
 
-    async def _load_ytm_history(self) -> None:
-        """Load the account play history from YT Music (YT Music tab)."""
+        The cache holds the whole normalized feed, unfiltered; views apply
+        their own limits. Plays the account accepted while no feed was
+        cached (see ``_add_to_ytm_history_cache`` on the app) are put ahead
+        of the fetched feed, so a fetch that started before such a report
+        cannot hide it.
+        """
         self._ytm_auth_required = False
         self._ytm_load_failed = False
-
-        # Reuse the app-level cache when present (populated on a prior visit)
-        # so we don't refetch every time.
-        cached = self._get_cache(_TAB_YTM)
-        if cached is not None:
-            if self._active_tab == _TAB_YTM:
-                self._display_tracks(cached)
-            return
-
         ytmusic = self.app.ytmusic  # type: ignore[attr-defined]
         if not ytmusic:
             self._ytm_auth_required = True
-            if self._active_tab == _TAB_YTM:
-                self._display_tracks([])
             return
-
         # ``get_history`` requires auth; the service logs and returns None on
         # any failure (expired session, network, server error) so we can tell
-        # a genuine empty history from an error. The endpoint isn't paginated
-        # and hands back ~200 rows in one shot, so we cap it to _MAX_TRACKS to
-        # match the local tab and avoid overloading the TUI.
+        # a genuine empty history from an error.
         raw = await ytmusic.get_history()
         if raw is None:
             self._ytm_load_failed = True
-            tracks: list[dict] = []
-        else:
-            # The feed mixes genuine online plays with plays this app synced
-            # there (sync_history_to_ytmusic), so drop everything known to
-            # the local history — this tab shows online-only plays. On a
-            # local DB error, degrade to the unfiltered feed rather than an
-            # empty tab. Cap AFTER filtering so exclusions don't shrink the
-            # tab when the feed has enough online-only entries.
-            local_ids: set[str] = set()
-            filtered = True
-            history = self.app.history  # type: ignore[attr-defined]
-            if history:
-                try:
-                    local_ids = await history.get_played_video_ids()
-                except (OSError, sqlite3.Error, RuntimeError):
-                    logger.exception("Failed to load local ids for YT Music history filter")
-                    filtered = False
-            tracks = [t for t in normalize_tracks(raw) if get_video_id(t) not in local_ids]
-            tracks = tracks[:_MAX_TRACKS]
-            if filtered:
-                # Cache only successfully-filtered loads: caching a degraded
-                # (unfiltered) list would keep TUI plays on this tab for the
-                # rest of the session with no retry of the filter.
-                self._set_cache(_TAB_YTM, tracks)
+            return
+        tracks = normalize_tracks(raw)
+        pending = self._take_pending_account_plays()
+        if pending:
+            ids = {get_video_id(t) for t in pending}
+            tracks = pending + [t for t in tracks if get_video_id(t) not in ids]
+        self._set_cache(_TAB_YTM, tracks)
+
+    def _take_pending_account_plays(self) -> list[dict]:
+        pending = getattr(self.app, "_ytm_history_pending", None)
+        if not isinstance(pending, list) or not pending:
+            return []
+        taken = list(pending)
+        pending.clear()
+        return taken
+
+    async def _load_history(self) -> None:
+        """Load the local SQLite play history (Local tab)."""
+        if not self.app.history:  # type: ignore[attr-defined]
+            self.query_one("#recent-loading", Label).update("History not available.")
+            return
+        await self._fetch_local()
+        if self._active_tab == _TAB_LOCAL:
+            self._display_tracks(self._rows_for(_TAB_LOCAL))
+
+    async def _load_ytm_history(self) -> None:
+        """Load the account play history from YT Music (YT Music tab)."""
+        # Reuse the app-level cache when present (populated on a prior visit)
+        # so we don't refetch every time.
+        if self._get_cache(_TAB_YTM) is None:
+            await self._fetch_ytm()
         if self._active_tab == _TAB_YTM:
-            self._display_tracks(tracks)
+            self._display_tracks(self._rows_for(_TAB_YTM))
+
+    async def _load_all(self) -> None:
+        """Load whichever sources aren't cached yet, then render All from both."""
+        fetches = []
+        if self._get_cache(_TAB_LOCAL) is None:
+            fetches.append(self._fetch_local())
+        if self._get_cache(_TAB_YTM) is None:
+            fetches.append(self._fetch_ytm())
+        if fetches:
+            await asyncio.gather(*fetches)
+        if self._active_tab == _TAB_ALL:
+            self._display_tracks(self._rows_for(_TAB_ALL))
+
+    # ── Live updates ─────────────────────────────────────────────────
 
     def optimistic_add(self, index: int, track: dict) -> None:
-        """Prepend a just-played track to a tab's cache and re-render live.
+        """Prepend a just-played track to a source's cache and re-render live.
 
-        Mirrors the server's most-recent-first dedup: drops any existing
-        entry for the same track, inserts the current one at the top, and
-        caps the list at ``_MAX_TRACKS``. No-op until the tab has a cache
-        (the first visit fetches the real list). If the tab is showing, it
-        refreshes with the cursor kept on the same track.
+        Dedups by ``video_id``: an existing row for the same track moves to
+        the top. The Local cache stays capped at ``_MAX_TRACKS`` (its query
+        limit); the account cache is unfiltered and capped on display. No-op
+        until the source has a cache (the first visit fetches the real list).
+        If the source, or All, is showing, it re-renders.
         """
         cache = self._get_cache(index)
         if cache is None:
             return
         video_id = get_video_id(track)
         updated = [dict(track)] + [t for t in cache if get_video_id(t) != video_id]
-        del updated[_MAX_TRACKS:]
+        if index == _TAB_LOCAL:
+            updated = updated[:_MAX_TRACKS]
         self._set_cache(index, updated)
         self._refresh_tab_from_cache(index)
 
     def _refresh_tab_from_cache(self, index: int) -> None:
-        """Re-render *index* from its cache after a background update.
+        """Re-render after a background change to source *index*'s cache.
 
-        Never steals focus, reapplies the active ``/`` filter, and keeps the
-        cursor on the same track by identity (a prepend shifts rows down one,
-        but a dedup that moves an existing row is net-zero, so a blanket +1
-        would drift).
+        Re-renders when that source is showing, or when All is showing (it
+        draws from both sources). Never steals focus: the change lands from
+        playback timers, not user input, and the user may be typing in the
+        filter. The cursor stays on the same track and the filter is
+        reapplied.
         """
-        if self._active_tab != index:
+        if self._active_tab not in (index, _TAB_ALL):
             return
-        cache = self._get_cache(index)
-        if cache is None:
+        if self._active_tab != _TAB_ALL and self._get_cache(index) is None:
             return
+        rows = self._rows_for(self._active_tab)
         query = ""
         try:
-            query = self.query_one("#track-filter", Input).value.strip()
+            query = self.query_one("#track-filter", Input).value
         except Exception:
             logger.debug("Failed to read track filter on tab refresh", exc_info=True)
         try:
             table = self.query_one("#recent-table", TrackTable)
-            # While a filter is active the cursor restore is skipped:
-            # apply_filter rebuilds the visible rows on a debounce, so a row
-            # index computed now would race it — and the user is typing in
-            # the Input at that moment, not driving the table cursor.
-            # selected_track maps the visible cursor row through any active
-            # sort; the reload below resets the sort, so the cache index is
-            # the right restore target.
+            # Keep the cursor on the SAME TRACK, not the same row number —
+            # the prepend shifts every row down by one. Identity comes from
+            # the highlighted VISIBLE row (mapped through any active sort),
+            # not a backing-list index. The reload below resets the sort, so
+            # the target row is that track's index in the new rows.
             cursored = table.selected_track
-            if not query and cursored is not None:
-                cursored_id = get_video_id(cursored)
-                for i, t in enumerate(cache):
-                    if get_video_id(t) == cursored_id:
-                        self._restore_cursor_row = i
+            keep_row = None
+            if cursored is not None:
+                for i, t in enumerate(rows):
+                    if get_video_id(t) == get_video_id(cursored):
+                        keep_row = i
                         break
+            self._restore_cursor_row = keep_row
         except Exception:
             logger.debug("Failed to preserve cursor on tab refresh", exc_info=True)
-        self._display_tracks(cache, focus=False)
+        self._display_tracks(rows, focus=False)
         if query:
             try:
                 self.query_one("#recent-table", TrackTable).apply_filter(query)
             except Exception:
                 logger.debug("Failed to reapply track filter on tab refresh", exc_info=True)
+
+    # ── Rendering ────────────────────────────────────────────────────
 
     def _display_tracks(self, tracks: list[dict], *, focus: bool = True) -> None:
         table = self.query_one("#recent-table", TrackTable)
@@ -376,19 +468,7 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
             self.track_count = 0
             self.query_one("#recent-footer", Static).update("")
             table.display = False
-            # Read only the ACTIVE tab's failure flags: the other tab's
-            # failure copy must not leak onto this one.
-            if self._active_tab == _TAB_YTM:
-                if self._ytm_auth_required:
-                    loading.update(_YTM_AUTH_REQUIRED_MSG)
-                elif self._ytm_load_failed:
-                    loading.update(_YTM_LOAD_FAILED_MSG)
-                else:
-                    loading.update("No YT Music play history found.")
-            elif self._load_failed:
-                loading.update(_HISTORY_LOAD_FAILED_MSG)
-            else:
-                loading.update("No play history yet. Start listening!")
+            loading.update(self._empty_message())
             loading.display = True
             return
 
@@ -397,9 +477,7 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
         table.load_tracks(tracks)
 
         self.track_count = len(tracks)
-        footer = self.query_one("#recent-footer", Static)
-        source = "YT Music" if self._active_tab == _TAB_YTM else "local"
-        footer.update(f"{len(tracks)} recently played tracks ({source})")
+        self.query_one("#recent-footer", Static).update(self._footer_text(len(tracks)))
 
         # Restore cursor position from navigation state.
         row = self._restore_cursor_row
@@ -413,10 +491,55 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
         if focus:
             table.focus()
 
+    def _empty_message(self) -> str:
+        """Empty-state copy for the ACTIVE tab; the other tabs' failures never leak in."""
+        if self._active_tab == _TAB_YTM:
+            if self._ytm_auth_required:
+                return _YTM_AUTH_REQUIRED_MSG
+            if self._ytm_load_failed:
+                return _YTM_LOAD_FAILED_MSG
+            return "No YT Music play history found."
+        if self._active_tab == _TAB_LOCAL:
+            return (
+                _HISTORY_LOAD_FAILED_MSG
+                if self._load_failed
+                else "No play history yet. Start listening!"
+            )
+        # All: name every source that is missing instead of claiming an empty
+        # history the user may well have.
+        problems = []
+        if self._load_failed:
+            problems.append("Couldn't load local history")
+        if self._ytm_auth_required:
+            problems.append("sign in to YT Music to include your account history")
+        elif self._ytm_load_failed:
+            problems.append("couldn't load YT Music history")
+        if not problems:
+            return "No play history yet. Start listening!"
+        message = "; ".join(problems) + "."
+        if self._load_failed or self._ytm_load_failed:
+            message += " Check the log at ~/.config/ytm-player/logs/ytm.log for details."
+        return message
+
+    def _footer_text(self, count: int) -> str:
+        if self._active_tab == _TAB_LOCAL:
+            return f"{count} recently played tracks (local)"
+        if self._active_tab == _TAB_YTM:
+            return f"{count} recently played tracks (YT Music)"
+        text = f"{count} tracks — local history first, then additional account history"
+        # Partial results are said out loud: a missing source is not an empty one.
+        if self._load_failed:
+            text += " — local history couldn't be loaded; showing YT Music only"
+        elif self._ytm_auth_required:
+            text += " — sign in to YT Music to include your account history"
+        elif self._ytm_load_failed:
+            text += " — YT Music history couldn't be loaded; showing local only"
+        return text
+
     def get_nav_state(self) -> dict[str, Any]:
         """Return state to preserve when navigating away."""
         state: dict[str, Any] = {}
-        if self._active_tab != _TAB_LOCAL:
+        if self._active_tab != _DEFAULT_TAB:
             state["active_tab"] = self._active_tab
         try:
             table = self.query_one("#recent-table", TrackTable)
@@ -458,7 +581,6 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
                 return
 
         table = self.query_one("#recent-table", TrackTable)
-
         match action:
             case _:
                 await table.handle_action(action, count)
@@ -469,29 +591,27 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
         Re-selecting the tab that's already active refreshes it (drops the
         cache and refetches) — handy for the YT Music tab, which otherwise
         keeps showing the cached snapshot from when it was first opened.
+        Refreshing All refetches both sources.
         """
         if index == self._active_tab:
             self._reload_active_tab()
             return
+
         self._active_tab = index
-
-        # Update tab label styling.
-        local_tab = self.query_one("#recent-tab-local", Static)
-        ytm_tab = self.query_one("#recent-tab-ytm", Static)
-        local_tab.set_class(index == _TAB_LOCAL, "active")
-        ytm_tab.set_class(index == _TAB_YTM, "active")
-
+        # Update tab label styling and the one-line description.
+        for tab_index, widget_id in _TAB_IDS.items():
+            self.query_one(f"#{widget_id}", Static).set_class(tab_index == index, "active")
+        self.query_one("#recent-tab-desc", Static).update(_TAB_DESCRIPTIONS[index])
         self._reset_filter()
 
-        cached = self._get_cache(index)
-        if cached is not None:
-            self._display_tracks(cached)
+        if self._sources_cached(index):
+            self._display_tracks(self._rows_for(index))
         else:
             self._show_loading()
             self._load_active_tab()
 
     def _reload_active_tab(self) -> None:
-        """Drop the active tab's cache and refetch it."""
+        """Drop the active tab's cache(s) and refetch."""
         self._clear_cache(self._active_tab)
         self._reset_filter()
         self._show_loading()
@@ -517,12 +637,12 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
         if widget_id == "start-radio-btn":
             event.stop()
             self.run_worker(self._start_radio(), name="start_radio", exclusive=True)
-        elif widget_id == "recent-tab-local":
-            event.stop()
-            self._switch_tab(_TAB_LOCAL)
-        elif widget_id == "recent-tab-ytm":
-            event.stop()
-            self._switch_tab(_TAB_YTM)
+            return
+        for index, tab_id in _TAB_IDS.items():
+            if widget_id == tab_id:
+                event.stop()
+                self._switch_tab(index)
+                return
 
     async def _start_radio(self) -> None:
         import random

--- a/tests/test_app/test_ytm_history_report.py
+++ b/tests/test_app/test_ytm_history_report.py
@@ -34,6 +34,7 @@ def _host(
     host._play_generation = play_generation
     host._ytm_reported_generation = reported_generation
     host._ytm_history = None
+    host._ytm_history_pending = []
     host._local_history_claim = None
     host._track_start_position = 0.0
     host.history = MagicMock()
@@ -50,6 +51,7 @@ def _host(
     # Bind the push coroutine too: _report_ytm_play hands it to run_worker,
     # and an auto-mocked method there would hide the real coroutine contract.
     host._push_ytm_history_report = PlaybackMixin._push_ytm_history_report.__get__(host)
+    host._add_to_ytm_history_cache = PlaybackMixin._add_to_ytm_history_cache.__get__(host)
     return host
 
 
@@ -306,18 +308,31 @@ def test_ytm_report_fires_even_when_current_track_cleared() -> None:
     host.run_worker.call_args.args[0].close()  # unawaited coroutine cleanup
 
 
-async def test_push_marks_on_server_accept_without_touching_ytm_tab() -> None:
-    """The YT Music tab shows online-only plays: a successful report must
-    mark the generation but never inject the TUI play into the tab cache."""
+async def test_push_adds_the_accepted_play_to_the_account_cache() -> None:
+    """Once the account accepted the play it belongs on the YT Music and All
+    tabs: mark the generation and move the track to the top of the cache."""
     host = _host(play_generation=3, position=DEFAULT_HISTORY_MIN_LISTEN_SECONDS + 1)
     host.ytmusic.add_history_item = AsyncMock(return_value=True)
-    host._ytm_history = [{"video_id": "old"}]
+    host._ytm_history = [{"video_id": "old"}, {"video_id": "vid1", "title": "stale"}]
 
-    await PlaybackMixin._push_ytm_history_report.__get__(host)("vid1", 3)
+    track = {"video_id": "vid1", "title": "Fresh"}
+    await PlaybackMixin._push_ytm_history_report.__get__(host)(track, "vid1", 3)
 
     host.ytmusic.add_history_item.assert_awaited_once_with("vid1")
     assert host._ytm_reported_generation == 3
-    assert host._ytm_history == [{"video_id": "old"}]
+    assert host._ytm_history == [{"video_id": "vid1", "title": "Fresh"}, {"video_id": "old"}]
+    assert host._ytm_history_pending == []
+
+
+async def test_push_parks_the_accepted_play_when_no_feed_is_cached() -> None:
+    host = _host(play_generation=3, position=DEFAULT_HISTORY_MIN_LISTEN_SECONDS + 1)
+    host.ytmusic.add_history_item = AsyncMock(return_value=True)
+    host._ytm_history = None
+
+    await PlaybackMixin._push_ytm_history_report.__get__(host)({"video_id": "vid1"}, "vid1", 3)
+
+    assert host._ytm_history is None
+    assert host._ytm_history_pending == [{"video_id": "vid1"}]
 
 
 async def test_push_failure_leaves_tab_and_marking_untouched() -> None:
@@ -326,7 +341,9 @@ async def test_push_failure_leaves_tab_and_marking_untouched() -> None:
     host.ytmusic.add_history_item = AsyncMock(return_value=False)
     host._ytm_history = [{"video_id": "old"}]
 
-    await PlaybackMixin._push_ytm_history_report.__get__(host)("vid1", 3)
+    await PlaybackMixin._push_ytm_history_report.__get__(host)({"video_id": "vid1"}, "vid1", 3)
+
+    assert host._ytm_history_pending == []
 
     assert host._ytm_reported_generation == -1
     assert host._ytm_history == [{"video_id": "old"}]
@@ -615,66 +632,84 @@ def test_optimistic_local_add_noop_when_page_closed() -> None:
     # No RecentlyPlayedPage → nothing to assert beyond no exception.
 
 
-# ── YT Music cache eviction on local plays ───────────────────────────
+# ── Account cache updates on accepted plays ──────────────────────────
 
 
-def test_ytm_cache_eviction_drops_matching_row() -> None:
-    """Once a play lands in local history, a fresh YT Music fetch would
-    filter it out — the populated cache must drop it too (disjoint tabs)."""
+def test_ytm_cache_update_moves_the_play_to_the_top() -> None:
     host = MagicMock()
-    host._ytm_history = [{"video_id": "a"}, {"video_id": "vid1"}]
+    host._ytm_history = [{"video_id": "a"}, {"video_id": "vid1", "title": "old"}]
+    host._ytm_history_pending = []
     host._get_current_page.return_value = MagicMock()  # not a RecentlyPlayedPage
-    PlaybackMixin._drop_from_ytm_history_cache.__get__(host)("vid1")
-    assert [t["video_id"] for t in host._ytm_history] == ["a"]
+
+    PlaybackMixin._add_to_ytm_history_cache.__get__(host)({"video_id": "vid1", "title": "new"})
+
+    assert host._ytm_history == [{"video_id": "vid1", "title": "new"}, {"video_id": "a"}]
 
 
-def test_ytm_cache_eviction_noop_when_cache_unfetched() -> None:
+def test_ytm_cache_update_rerenders_the_open_page() -> None:
+    from ytm_player.ui.pages.recently_played import _TAB_YTM, RecentlyPlayedPage
+
+    host = MagicMock()
+    host._ytm_history = [{"video_id": "a"}]
+    host._ytm_history_pending = []
+    page = MagicMock(spec=RecentlyPlayedPage)
+    host._get_current_page.return_value = page
+
+    PlaybackMixin._add_to_ytm_history_cache.__get__(host)({"video_id": "vid1"})
+
+    page._refresh_tab_from_cache.assert_called_once_with(_TAB_YTM)
+
+
+def test_ytm_cache_update_pending_is_deduped_and_bounded() -> None:
+    from ytm_player.app._playback import _YTM_PENDING_MAX
+
     host = MagicMock()
     host._ytm_history = None
-    PlaybackMixin._drop_from_ytm_history_cache.__get__(host)("vid1")
-    assert host._ytm_history is None
+    host._ytm_history_pending = [{"video_id": f"p{i}"} for i in range(_YTM_PENDING_MAX)]
+    add = PlaybackMixin._add_to_ytm_history_cache.__get__(host)
+
+    add({"video_id": "p3", "title": "again"})
+    assert host._ytm_history_pending[0] == {"video_id": "p3", "title": "again"}
+    assert len(host._ytm_history_pending) == _YTM_PENDING_MAX
+
+    add({"video_id": "brand-new"})
+    assert host._ytm_history_pending[0] == {"video_id": "brand-new"}
+    assert len(host._ytm_history_pending) == _YTM_PENDING_MAX
+    host._get_current_page.assert_not_called()
 
 
-async def test_local_insert_worker_evicts_from_ytm_cache() -> None:
+def test_ytm_cache_update_ignores_a_track_without_an_id() -> None:
+    host = MagicMock()
+    host._ytm_history = [{"video_id": "a"}]
+    PlaybackMixin._add_to_ytm_history_cache.__get__(host)({"title": "no id"})
+    assert host._ytm_history == [{"video_id": "a"}]
+
+
+async def test_local_insert_leaves_the_account_cache_alone() -> None:
+    """A local play is local history; the account cache changes only when the
+    account itself accepted the play (see _push_ytm_history_report)."""
     host = _host(play_generation=4)
+    host._add_to_ytm_history_cache = MagicMock()
     claim = _claim(generation=4, insert_started=True)
     host._local_history_claim = claim
     host.history.log_play = AsyncMock(return_value=123)
     host._optimistic_local_history_add = MagicMock()
+    host._ytm_history = [{"video_id": "vid1"}, {"video_id": "a"}]
 
     await _insert(host, claim)
 
-    host._drop_from_ytm_history_cache.assert_called_once_with("vid1")
+    assert host._ytm_history == [{"video_id": "vid1"}, {"video_id": "a"}]
+    host._add_to_ytm_history_cache.assert_not_called()
 
 
-async def test_failed_local_insert_does_not_evict() -> None:
-    host = _host()
-    claim = _claim(insert_started=True)
-    host._local_history_claim = claim
-    host.history.log_play = AsyncMock(return_value=None)
-
-    await _insert(host, claim)
-
-    host._drop_from_ytm_history_cache.assert_not_called()
-
-
-async def test_direct_log_finalize_evicts_from_ytm_cache() -> None:
+async def test_direct_log_finalize_leaves_the_account_cache_alone() -> None:
     host = _host(position=60)
+    host._add_to_ytm_history_cache = MagicMock()
     host._local_history_claim = None
     host.history.log_play = AsyncMock(return_value=7)
+    host._ytm_history = [{"video_id": "vid1"}]
 
     await _finalize(host)
 
-    host._drop_from_ytm_history_cache.assert_called_once_with("vid1")
-
-
-async def test_rejected_direct_log_does_not_evict() -> None:
-    """log_play returning None (below threshold) wrote no local row — the
-    track keeps its place on the YT Music tab."""
-    host = _host(position=60)
-    host._local_history_claim = None
-    host.history.log_play = AsyncMock(return_value=None)
-
-    await _finalize(host)
-
-    host._drop_from_ytm_history_cache.assert_not_called()
+    assert host._ytm_history == [{"video_id": "vid1"}]
+    host._add_to_ytm_history_cache.assert_not_called()

--- a/tests/test_app/test_ytm_history_report.py
+++ b/tests/test_app/test_ytm_history_report.py
@@ -35,6 +35,7 @@ def _host(
     host._ytm_reported_generation = reported_generation
     host._ytm_history = None
     host._ytm_history_pending = []
+    host._ytm_history_pending_seq = 0
     host._local_history_claim = None
     host._track_start_position = 0.0
     host.history = MagicMock()
@@ -332,7 +333,8 @@ async def test_push_parks_the_accepted_play_when_no_feed_is_cached() -> None:
     await PlaybackMixin._push_ytm_history_report.__get__(host)({"video_id": "vid1"}, "vid1", 3)
 
     assert host._ytm_history is None
-    assert host._ytm_history_pending == [{"video_id": "vid1"}]
+    assert host._ytm_history_pending == [(1, {"video_id": "vid1"})]
+    assert host._ytm_history_pending_seq == 1
 
 
 async def test_push_failure_leaves_tab_and_marking_untouched() -> None:
@@ -665,17 +667,39 @@ def test_ytm_cache_update_pending_is_deduped_and_bounded() -> None:
 
     host = MagicMock()
     host._ytm_history = None
-    host._ytm_history_pending = [{"video_id": f"p{i}"} for i in range(_YTM_PENDING_MAX)]
+    host._ytm_history_pending = [(i + 1, {"video_id": f"p{i}"}) for i in range(_YTM_PENDING_MAX)]
+    host._ytm_history_pending_seq = _YTM_PENDING_MAX
     add = PlaybackMixin._add_to_ytm_history_cache.__get__(host)
 
     add({"video_id": "p3", "title": "again"})
-    assert host._ytm_history_pending[0] == {"video_id": "p3", "title": "again"}
+    assert host._ytm_history_pending[0] == (
+        _YTM_PENDING_MAX + 1,
+        {"video_id": "p3", "title": "again"},
+    )
     assert len(host._ytm_history_pending) == _YTM_PENDING_MAX
+    assert [t["video_id"] for _s, t in host._ytm_history_pending].count("p3") == 1
 
     add({"video_id": "brand-new"})
-    assert host._ytm_history_pending[0] == {"video_id": "brand-new"}
+    assert host._ytm_history_pending[0] == (_YTM_PENDING_MAX + 2, {"video_id": "brand-new"})
     assert len(host._ytm_history_pending) == _YTM_PENDING_MAX
     host._get_current_page.assert_not_called()
+
+
+def test_ytm_cache_update_pending_sequence_numbers_only_grow() -> None:
+    """Each parked play gets a fresh, higher number — a replay of a track
+    that is already parked counts as a new, later play."""
+    host = MagicMock()
+    host._ytm_history = None
+    host._ytm_history_pending = []
+    host._ytm_history_pending_seq = 0
+    add = PlaybackMixin._add_to_ytm_history_cache.__get__(host)
+
+    add({"video_id": "a"})
+    add({"video_id": "b"})
+    add({"video_id": "a"})
+
+    assert host._ytm_history_pending == [(3, {"video_id": "a"}), (2, {"video_id": "b"})]
+    assert host._ytm_history_pending_seq == 3
 
 
 def test_ytm_cache_update_ignores_a_track_without_an_id() -> None:

--- a/tests/test_integration/test_page_failure_states.py
+++ b/tests/test_integration/test_page_failure_states.py
@@ -53,7 +53,7 @@ def _make_recently_played_page() -> tuple[RecentlyPlayedPage, dict[str, MagicMoc
     ``query_one`` selector so tests can introspect ``.update`` calls
     and ``.display`` flips.
     """
-    page = RecentlyPlayedPage()
+    page = RecentlyPlayedPage(active_tab=_TAB_LOCAL)
 
     loading = MagicMock(name="recent-loading")
     table = MagicMock(name="recent-table")

--- a/tests/test_ui/test_recently_played_render.py
+++ b/tests/test_ui/test_recently_played_render.py
@@ -1,0 +1,120 @@
+"""Rendered-width regression tests for the Recently Played status lines.
+
+The All tab's partial-results notice and the description under the tab row
+are longer than an 80-column terminal. Asserting on the string handed to
+``update()`` proves nothing about what the user sees, so these mount the
+real page in a headless Textual app and read back the rendered lines.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.geometry import Region
+from textual.widget import Widget
+from textual.widgets import Static
+
+from ytm_player.ui.pages.recently_played import _TAB_ALL, _TAB_DESCRIPTIONS, RecentlyPlayedPage
+
+_LOCAL = [
+    {
+        "video_id": f"loc{i}",
+        "title": f"Local {i}",
+        "artist": "Artist",
+        "album": "Album",
+        "duration_seconds": 100,
+        "played_at": f"2026-09-06T12:{59 - i:02d}:00",
+    }
+    for i in range(3)
+]
+_FEED = [
+    {
+        "videoId": f"acc{i}",
+        "title": f"Phone play {i}",
+        "artists": [{"name": "Artist", "id": "A1"}],
+        "album": {"name": "Album", "id": "AL1"},
+        "duration": "2:00",
+    }
+    for i in range(2)
+]
+
+
+class _Host(App):
+    """Minimal host exposing the attributes RecentlyPlayedPage reads."""
+
+    def __init__(self, *, local, local_error=None, feed=None, ytmusic=True) -> None:
+        super().__init__()
+        self.history = MagicMock()
+        if local_error is not None:
+            self.history.get_recently_played = AsyncMock(side_effect=local_error)
+        else:
+            self.history.get_recently_played = AsyncMock(return_value=list(local))
+        if ytmusic:
+            self.ytmusic = MagicMock()
+            self.ytmusic.get_history = AsyncMock(return_value=feed)
+        else:
+            self.ytmusic = None
+        self._ytm_history = None
+        self._ytm_history_pending = []
+        self._ytm_history_pending_seq = 0
+
+    def get_css_variables(self) -> dict[str, str]:
+        variables = super().get_css_variables()
+        variables["selected-item"] = "#3a3a3a"
+        return variables
+
+    def compose(self) -> ComposeResult:
+        yield RecentlyPlayedPage(id="page")
+
+
+def _rendered_text(widget: Widget) -> str:
+    """The text actually painted for *widget*, wrapped lines joined by a space."""
+    size = widget.outer_size
+    strips = widget.render_lines(Region(0, 0, size.width, size.height))
+    return " ".join(strip.text.strip() for strip in strips if strip.text.strip())
+
+
+async def _render_all_tab(host: _Host, width: int) -> tuple[str, str]:
+    async with host.run_test(size=(width, 24)) as pilot:
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+        page = host.query_one("#page", RecentlyPlayedPage)
+        assert page._active_tab == _TAB_ALL
+        footer = _rendered_text(page.query_one("#recent-footer", Static))
+        description = _rendered_text(page.query_one("#recent-tab-desc", Static))
+        return footer, description
+
+
+@pytest.mark.parametrize("width", [80, 100, 120])
+async def test_both_sources_footer_and_description_are_fully_visible(width: int) -> None:
+    footer, description = await _render_all_tab(_Host(local=_LOCAL, feed=_FEED), width)
+
+    assert footer == "5 tracks — local history first, then additional account history"
+    assert description == _TAB_DESCRIPTIONS[_TAB_ALL]
+
+
+@pytest.mark.parametrize("width", [80, 100, 120])
+async def test_ytm_failure_notice_is_fully_visible(width: int) -> None:
+    footer, description = await _render_all_tab(_Host(local=_LOCAL, feed=None), width)
+
+    assert footer == "YT Music history couldn't be loaded; showing local history only — 3 tracks"
+    assert description == _TAB_DESCRIPTIONS[_TAB_ALL]
+
+
+@pytest.mark.parametrize("width", [80, 100, 120])
+async def test_sign_in_notice_is_fully_visible(width: int) -> None:
+    footer, _ = await _render_all_tab(_Host(local=_LOCAL, ytmusic=False), width)
+
+    assert footer == (
+        "Sign in to YT Music to include your account history; showing local history only — 3 tracks"
+    )
+
+
+@pytest.mark.parametrize("width", [80, 100, 120])
+async def test_local_failure_notice_is_fully_visible(width: int) -> None:
+    host = _Host(local=[], local_error=OSError("locked"), feed=_FEED)
+    footer, _ = await _render_all_tab(host, width)
+
+    assert footer == "Local history couldn't be loaded; showing YT Music history only — 2 tracks"

--- a/tests/test_ui/test_recently_played_tabs.py
+++ b/tests/test_ui/test_recently_played_tabs.py
@@ -7,7 +7,8 @@
 - a source that fails leaves All showing the other with an explicit note,
 - All is the default tab, navigation state restores the others,
 - live updates (a local play, a play the account accepted) re-render All,
-- a fetch that started before an accepted play cannot hide that play.
+- a fetch that started before an accepted play cannot hide that play, while
+  a play accepted before the fetch keeps its server position.
 
 Like ``test_page_failure_states``, we exercise the page methods directly
 and replace the widgets the page queries with ``MagicMock`` at the
@@ -21,6 +22,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ytm_player.app._playback import PlaybackMixin
 from ytm_player.config.keymap import Action
 from ytm_player.ui.pages.recently_played import (
     _DEFAULT_TAB,
@@ -76,6 +78,9 @@ def _fake_app(
     app = MagicMock()
     app._ytm_history = None
     app._ytm_history_pending = []
+    app._ytm_history_pending_seq = 0
+    # The real parking code, so the pending entries look like the app's.
+    app._add_to_ytm_history_cache = PlaybackMixin._add_to_ytm_history_cache.__get__(app)
     if local_error is not None:
         app.history.get_recently_played = AsyncMock(side_effect=local_error)
     else:
@@ -184,28 +189,49 @@ async def test_ytm_tab_no_service_shows_auth_message(monkeypatch) -> None:
     assert any("Sign in to YT Music" in m for m in _loading_messages(widgets))
 
 
-async def test_ytm_fetch_puts_pending_accepted_plays_ahead_of_the_feed(monkeypatch) -> None:
+async def test_ytm_fetch_keeps_server_order_for_a_play_accepted_before_it_started(
+    monkeypatch,
+) -> None:
+    """A play the account accepted BEFORE the fetch began is already in the
+    feed it returns: the server's position and row stand. Putting it on top
+    would reorder a feed that is newer than the report."""
     page, widgets = _make_page(active_tab=_TAB_YTM)
-    fake_app = _fake_app(feed=_raw_tracks(3))
-    fake_app._ytm_history_pending = [{"video_id": "vid0001", "title": "Accepted"}]
+    feed = [{**_raw_tracks(1, prefix="phone")[0]}, {**_raw_tracks(1, prefix="tui")[0]}]
+    fake_app = _fake_app(feed=feed)
+    fake_app._add_to_ytm_history_cache({"video_id": "tui0000", "title": "Accepted earlier"})
     _attach_fake_app(page, fake_app, monkeypatch)
 
     await page._load_ytm_history()
 
-    assert _ids(fake_app._ytm_history) == ["vid0001", "vid0000", "vid0002"]
-    assert fake_app._ytm_history[0]["title"] == "Accepted"
+    assert _ids(fake_app._ytm_history) == ["phone0000", "tui0000"]
+    assert fake_app._ytm_history[1]["title"] == "Song 0"
+    assert fake_app._ytm_history_pending == []
+
+
+async def test_ytm_fetch_puts_an_earlier_accepted_play_ahead_only_when_the_feed_lacks_it(
+    monkeypatch,
+) -> None:
+    page, widgets = _make_page(active_tab=_TAB_YTM)
+    fake_app = _fake_app(feed=_raw_tracks(2))
+    fake_app._add_to_ytm_history_cache({"video_id": "missing", "title": "Not in the feed yet"})
+    _attach_fake_app(page, fake_app, monkeypatch)
+
+    await page._load_ytm_history()
+
+    assert _ids(fake_app._ytm_history) == ["missing", "vid0000", "vid0001"]
     assert fake_app._ytm_history_pending == []
 
 
 async def test_ytm_fetch_in_flight_cannot_hide_a_newer_accepted_play(monkeypatch) -> None:
-    """A report the account accepts while get_history() is still running is
-    parked as pending; the older fetch merges it in instead of overwriting."""
+    """A report the account accepts while get_history() is still running
+    post-dates the feed: it goes on top even though the (stale) feed lists
+    the track further down, and the older fetch cannot overwrite it."""
     page, widgets = _make_page(active_tab=_TAB_YTM)
     release = asyncio.Event()
 
     async def slow_history():
         await release.wait()
-        return _raw_tracks(2)
+        return _raw_tracks(2) + [{**_raw_tracks(1)[0], "videoId": "new", "title": "Stale row"}]
 
     fake_app = _fake_app()
     fake_app.ytmusic.get_history = AsyncMock(side_effect=slow_history)
@@ -213,12 +239,51 @@ async def test_ytm_fetch_in_flight_cannot_hide_a_newer_accepted_play(monkeypatch
 
     fetch = asyncio.create_task(page._load_ytm_history())
     await asyncio.sleep(0)  # the fetch is now waiting on get_history()
-    fake_app._ytm_history_pending.append({"video_id": "new", "title": "Just played"})
+    fake_app._add_to_ytm_history_cache({"video_id": "new", "title": "Just played"})
     release.set()
     await fetch
 
     assert _ids(fake_app._ytm_history) == ["new", "vid0000", "vid0001"]
+    assert fake_app._ytm_history[0]["title"] == "Just played"
     assert _ids(_loaded(widgets)) == ["new", "vid0000", "vid0001"]
+    assert fake_app._ytm_history_pending == []
+
+
+async def test_ytm_fetch_orders_pending_plays_newer_first_then_earlier_missing(
+    monkeypatch,
+) -> None:
+    page, widgets = _make_page(active_tab=_TAB_YTM)
+    release = asyncio.Event()
+
+    async def slow_history():
+        await release.wait()
+        return _raw_tracks(1) + [{**_raw_tracks(1)[0], "videoId": "before-present"}]
+
+    fake_app = _fake_app()
+    fake_app.ytmusic.get_history = AsyncMock(side_effect=slow_history)
+    fake_app._add_to_ytm_history_cache({"video_id": "before-missing"})
+    fake_app._add_to_ytm_history_cache({"video_id": "before-present"})
+    _attach_fake_app(page, fake_app, monkeypatch)
+
+    fetch = asyncio.create_task(page._load_ytm_history())
+    await asyncio.sleep(0)
+    fake_app._add_to_ytm_history_cache({"video_id": "during"})
+    release.set()
+    await fetch
+
+    assert _ids(fake_app._ytm_history) == ["during", "before-missing", "vid0000", "before-present"]
+
+
+async def test_ytm_fetch_failure_leaves_pending_plays_parked(monkeypatch) -> None:
+    page, widgets = _make_page(active_tab=_TAB_YTM)
+    fake_app = _fake_app(feed=None)
+    fake_app._add_to_ytm_history_cache({"video_id": "parked"})
+    _attach_fake_app(page, fake_app, monkeypatch)
+
+    await page._load_ytm_history()
+
+    assert fake_app._ytm_history is None
+    assert [t["video_id"] for _seq, t in fake_app._ytm_history_pending] == ["parked"]
 
 
 # ── Local loader ─────────────────────────────────────────────────────
@@ -281,6 +346,45 @@ def test_compose_all_overlap_keeps_local_row_and_fills_missing_metadata() -> Non
     assert row["is_video"] is False
 
 
+def test_compose_all_overlap_fills_absent_none_and_empty_fields() -> None:
+    """Whatever form 'lacking' takes in the local row — absent, None or "" —
+    the account value fills it, without touching what the local row has."""
+    local = [
+        {
+            "video_id": "loc0000",
+            "title": "Local title",
+            "artist": "",
+            "album": None,
+            "duration_seconds": 180,
+            "played_at": "2026-09-06T12:59:00",
+        }
+    ]
+    account = [
+        {
+            "video_id": "loc0000",
+            "title": "Server title",
+            "artist": "Server artist",
+            "album": "Server album",
+            "album_id": "AL1",
+            "thumbnail_url": "",
+            "played_at": "Today",
+        }
+    ]
+
+    (row,) = _compose_all(local, account)
+
+    assert row["artist"] == "Server artist"
+    assert row["album"] == "Server album"
+    assert row["album_id"] == "AL1"
+    assert row["title"] == "Local title"
+    assert row["played_at"] == "2026-09-06T12:59:00"
+    assert row["duration_seconds"] == 180
+    # An empty account value is no enrichment: the key stays absent.
+    assert "thumbnail_url" not in row
+    # The local row itself is untouched.
+    assert local[0]["artist"] == "" and local[0]["album"] is None
+
+
 def test_compose_all_dedups_before_the_account_only_cap() -> None:
     """100 local rows all present in a 200-row feed: All is 100 local plus the
     100 account-only rows, not 100 local plus nothing."""
@@ -339,7 +443,10 @@ async def test_all_tab_shows_local_only_with_a_note_when_ytm_fails(monkeypatch) 
     await page._load_all()
 
     assert _ids(_loaded(widgets)) == ["loc0000", "loc0001"]
-    assert "YT Music history couldn't be loaded" in _footer(widgets)
+    assert _footer(widgets).startswith(
+        "YT Music history couldn't be loaded; showing local history only"
+    )
+    assert "2 tracks" in _footer(widgets)
     assert fake_app._ytm_history is None
 
 
@@ -351,7 +458,9 @@ async def test_all_tab_shows_account_only_with_a_note_when_local_fails(monkeypat
     await page._load_all()
 
     assert _ids(_loaded(widgets)) == ["vid0000", "vid0001"]
-    assert "local history couldn't be loaded" in _footer(widgets)
+    assert _footer(widgets).startswith(
+        "Local history couldn't be loaded; showing YT Music history only"
+    )
     assert page._get_cache(_TAB_LOCAL) is None
 
 
@@ -362,7 +471,7 @@ async def test_all_tab_without_a_service_shows_local_with_a_sign_in_note(monkeyp
     await page._load_all()
 
     assert _ids(_loaded(widgets)) == ["loc0000", "loc0001"]
-    assert "sign in to YT Music" in _footer(widgets)
+    assert _footer(widgets).startswith("Sign in to YT Music to include your account history")
 
 
 async def test_all_tab_says_which_sources_failed_when_nothing_loads(monkeypatch) -> None:

--- a/tests/test_ui/test_recently_played_tabs.py
+++ b/tests/test_ui/test_recently_played_tabs.py
@@ -1,13 +1,13 @@
-"""Tests for the Recently Played page's Local / YT Music tabs.
+"""Tests for the Recently Played page's All / Local / YT Music tabs.
 
-Covers the behaviour added when the page gained a second tab backed by
-the YT Music account history (``get_history()``):
-
-- the YT Music loader normalises the server rows, filters out locally-played
-  tracks (the tab shows online-only plays), and caps at ``_MAX_TRACKS``,
-- empty / missing-service states render the right message,
-- the local loader honours the same cap,
-- keyboard tab switching (Enter on a focused tab label) works.
+- the YT Music loader shows the account's whole feed (nothing played locally
+  is hidden), keeps the unfiltered feed cached and caps on display,
+- All is derived from both sources: local rows first, then account-only rows
+  in server order, one row per track, each source capped separately,
+- a source that fails leaves All showing the other with an explicit note,
+- All is the default tab, navigation state restores the others,
+- live updates (a local play, a play the account accepted) re-render All,
+- a fetch that started before an accepted play cannot hide that play.
 
 Like ``test_page_failure_states``, we exercise the page methods directly
 and replace the widgets the page queries with ``MagicMock`` at the
@@ -16,18 +16,22 @@ and replace the widgets the page queries with ``MagicMock`` at the
 
 from __future__ import annotations
 
-import sqlite3
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from ytm_player.config.keymap import Action
 from ytm_player.ui.pages.recently_played import (
+    _DEFAULT_TAB,
     _MAX_TRACKS,
+    _TAB_ALL,
+    _TAB_DESCRIPTIONS,
     _TAB_LOCAL,
     _TAB_YTM,
     RecentlyPlayedPage,
     RecentTab,
+    _compose_all,
 )
 
 
@@ -43,8 +47,10 @@ def _make_page(active_tab: int = _TAB_LOCAL):
         "#recent-loading": MagicMock(name="recent-loading"),
         "#recent-table": MagicMock(name="recent-table"),
         "#recent-footer": MagicMock(name="recent-footer"),
+        "#recent-tab-all": MagicMock(name="recent-tab-all"),
         "#recent-tab-local": MagicMock(name="recent-tab-local"),
         "#recent-tab-ytm": MagicMock(name="recent-tab-ytm"),
+        "#recent-tab-desc": MagicMock(name="recent-tab-desc"),
         "#track-filter": MagicMock(name="track-filter"),
     }
     widgets["#recent-table"].row_count = 0
@@ -59,11 +65,33 @@ def _make_page(active_tab: int = _TAB_LOCAL):
     return page, widgets
 
 
-def _raw_tracks(n: int) -> list[dict]:
+def _fake_app(
+    *,
+    local: list[dict] | None = None,
+    local_error: Exception | None = None,
+    feed: list[dict] | None = None,
+    ytmusic: bool = True,
+):
+    """An app whose history and ytmusic services answer with the given data."""
+    app = MagicMock()
+    app._ytm_history = None
+    app._ytm_history_pending = []
+    if local_error is not None:
+        app.history.get_recently_played = AsyncMock(side_effect=local_error)
+    else:
+        app.history.get_recently_played = AsyncMock(return_value=list(local or []))
+    if ytmusic:
+        app.ytmusic.get_history = AsyncMock(return_value=feed)
+    else:
+        app.ytmusic = None
+    return app
+
+
+def _raw_tracks(n: int, prefix: str = "vid") -> list[dict]:
     """n playlistItem-shaped rows as returned by get_history()."""
     return [
         {
-            "videoId": f"vid{i:04d}",
+            "videoId": f"{prefix}{i:04d}",
             "title": f"Song {i}",
             "artists": [{"name": "Artist", "id": "A1"}],
             "album": {"name": "Album", "id": "AL1"},
@@ -74,222 +102,427 @@ def _raw_tracks(n: int) -> list[dict]:
     ]
 
 
+def _local_rows(n: int, prefix: str = "loc") -> list[dict]:
+    """n rows as HistoryManager.get_recently_played() returns them, newest first."""
+    return [
+        {
+            "video_id": f"{prefix}{i:04d}",
+            "title": f"Local {i}",
+            "artist": "Artist",
+            "album": "Album",
+            "duration_seconds": 180,
+            "played_at": f"2026-09-06T12:{59 - i:02d}:00",
+        }
+        for i in range(n)
+    ]
+
+
+def _ids(rows: list[dict]) -> list[str]:
+    return [t["video_id"] for t in rows]
+
+
+def _loaded(widgets) -> list[dict]:
+    return widgets["#recent-table"].load_tracks.call_args.args[0]
+
+
+def _footer(widgets) -> str:
+    return str(widgets["#recent-footer"].update.call_args.args[0])
+
+
+def _loading_messages(widgets) -> list[str]:
+    return [str(c.args[0]) for c in widgets["#recent-loading"].update.call_args_list]
+
+
 # ── YT Music loader ──────────────────────────────────────────────────
 
 
-async def test_ytm_tab_caps_rows_at_max_tracks(monkeypatch: pytest.MonkeyPatch) -> None:
-    """get_history() returns ~200 unpaginated rows; the tab must slice to
-    _MAX_TRACKS so the TUI stays responsive."""
+async def test_ytm_tab_shows_the_whole_feed_and_caps_on_display(monkeypatch) -> None:
+    """Nothing played locally is hidden any more; the cache keeps the whole
+    normalized feed and the tab slices to _MAX_TRACKS when it renders."""
     page, widgets = _make_page(active_tab=_TAB_YTM)
-
-    fake_ytmusic = MagicMock()
-    fake_ytmusic.get_history = AsyncMock(return_value=_raw_tracks(200))
-    fake_app = MagicMock()
-    fake_app.ytmusic = fake_ytmusic
-    fake_app._ytm_history = None  # not cached yet → fetch
-    fake_app.history.get_played_video_ids = AsyncMock(return_value=set())
+    fake_app = _fake_app(feed=_raw_tracks(200))
     _attach_fake_app(page, fake_app, monkeypatch)
 
     await page._load_ytm_history()
 
-    widgets["#recent-table"].load_tracks.assert_called_once()
-    loaded = widgets["#recent-table"].load_tracks.call_args.args[0]
-    assert len(loaded) == _MAX_TRACKS
-    # App-level cache holds the same capped list.
-    assert len(fake_app._ytm_history) == _MAX_TRACKS
+    fake_app.history.get_played_video_ids.assert_not_called()
+    assert len(_loaded(widgets)) == _MAX_TRACKS
+    assert _loaded(widgets)[0]["video_id"] == "vid0000"
+    assert len(fake_app._ytm_history) == 200
 
 
-async def test_ytm_tab_filters_out_locally_played_tracks(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The account feed mixes online plays with plays this app synced there
-    (sync_history_to_ytmusic); the tab must show online-only rows."""
+async def test_ytm_tab_empty_history_message(monkeypatch) -> None:
     page, widgets = _make_page(active_tab=_TAB_YTM)
-
-    fake_ytmusic = MagicMock()
-    fake_ytmusic.get_history = AsyncMock(return_value=_raw_tracks(5))
-    fake_app = MagicMock()
-    fake_app.ytmusic = fake_ytmusic
-    fake_app._ytm_history = None
-    fake_app.history.get_played_video_ids = AsyncMock(return_value={"vid0001", "vid0003"})
-    _attach_fake_app(page, fake_app, monkeypatch)
-
-    await page._load_ytm_history()
-
-    loaded = widgets["#recent-table"].load_tracks.call_args.args[0]
-    assert [t["video_id"] for t in loaded] == ["vid0000", "vid0002", "vid0004"]
-    # The cache holds the filtered list too — TUI plays never enter it.
-    assert [t["video_id"] for t in fake_app._ytm_history] == ["vid0000", "vid0002", "vid0004"]
-
-
-async def test_ytm_tab_caps_after_filtering(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The _MAX_TRACKS cap applies to the FILTERED list: local exclusions
-    must not shrink the tab while the feed has enough online-only rows."""
-    page, widgets = _make_page(active_tab=_TAB_YTM)
-
-    fake_ytmusic = MagicMock()
-    fake_ytmusic.get_history = AsyncMock(return_value=_raw_tracks(200))
-    fake_app = MagicMock()
-    fake_app.ytmusic = fake_ytmusic
-    fake_app._ytm_history = None
-    # Exclude the first 50: 150 online-only rows remain, still >= _MAX_TRACKS.
-    fake_app.history.get_played_video_ids = AsyncMock(
-        return_value={f"vid{i:04d}" for i in range(50)}
-    )
-    _attach_fake_app(page, fake_app, monkeypatch)
-
-    await page._load_ytm_history()
-
-    loaded = widgets["#recent-table"].load_tracks.call_args.args[0]
-    assert len(loaded) == _MAX_TRACKS
-    assert loaded[0]["video_id"] == "vid0050"
-
-
-async def test_ytm_tab_local_db_error_degrades_to_unfiltered(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """If the local-id read fails, show the unfiltered feed — a local DB
-    error must not blank the online tab."""
-    page, widgets = _make_page(active_tab=_TAB_YTM)
-
-    fake_ytmusic = MagicMock()
-    fake_ytmusic.get_history = AsyncMock(return_value=_raw_tracks(5))
-    fake_app = MagicMock()
-    fake_app.ytmusic = fake_ytmusic
-    fake_app._ytm_history = None
-    fake_app.history.get_played_video_ids = AsyncMock(side_effect=sqlite3.Error("locked"))
-    _attach_fake_app(page, fake_app, monkeypatch)
-
-    await page._load_ytm_history()
-
-    loaded = widgets["#recent-table"].load_tracks.call_args.args[0]
-    assert len(loaded) == 5
-    # Degraded (unfiltered) data must NOT be cached — the next visit has to
-    # retry the filter instead of showing TUI plays all session.
-    assert fake_app._ytm_history is None
-
-
-async def test_ytm_tab_empty_history_message(monkeypatch: pytest.MonkeyPatch) -> None:
-    page, widgets = _make_page(active_tab=_TAB_YTM)
-
-    fake_ytmusic = MagicMock()
-    fake_ytmusic.get_history = AsyncMock(return_value=[])
-    fake_app = MagicMock()
-    fake_app.ytmusic = fake_ytmusic
-    fake_app._ytm_history = None
-    fake_app.history.get_played_video_ids = AsyncMock(return_value=set())
-    _attach_fake_app(page, fake_app, monkeypatch)
+    _attach_fake_app(page, _fake_app(feed=[]), monkeypatch)
 
     await page._load_ytm_history()
 
     widgets["#recent-table"].load_tracks.assert_called_once_with([])
-    msgs = [c.args[0] for c in widgets["#recent-loading"].update.call_args_list]
-    assert any("No YT Music play history found" in m for m in msgs), msgs
+    assert any("No YT Music play history found" in m for m in _loading_messages(widgets))
 
 
-async def test_ytm_tab_error_shows_load_failed_message(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_ytm_tab_error_shows_load_failed_message(monkeypatch) -> None:
     page, widgets = _make_page(active_tab=_TAB_YTM)
-
-    fake_ytmusic = MagicMock()
-    # None signals a load failure (auth expired / network / server error).
-    fake_ytmusic.get_history = AsyncMock(return_value=None)
-    fake_app = MagicMock()
-    fake_app.ytmusic = fake_ytmusic
-    fake_app._ytm_history = None
+    fake_app = _fake_app(feed=None)  # None = auth expired / network / server error
     _attach_fake_app(page, fake_app, monkeypatch)
 
     await page._load_ytm_history()
 
     assert fake_app._ytm_history is None
     widgets["#recent-table"].load_tracks.assert_called_once_with([])
-    msgs = [c.args[0] for c in widgets["#recent-loading"].update.call_args_list]
-    assert any("Couldn't load YT Music history" in m for m in msgs), msgs
+    assert any("Couldn't load YT Music history" in m for m in _loading_messages(widgets))
 
 
-async def test_ytm_tab_no_service_shows_auth_message(monkeypatch: pytest.MonkeyPatch) -> None:
-    """When there is no ytmusic service, the tab must prompt to sign in
-    rather than claim the history is empty."""
+async def test_ytm_tab_no_service_shows_auth_message(monkeypatch) -> None:
     page, widgets = _make_page(active_tab=_TAB_YTM)
-
-    fake_app = MagicMock()
-    fake_app.ytmusic = None
-    fake_app._ytm_history = None
-    _attach_fake_app(page, fake_app, monkeypatch)
+    _attach_fake_app(page, _fake_app(ytmusic=False), monkeypatch)
 
     await page._load_ytm_history()
 
     assert page._ytm_auth_required is True
     widgets["#recent-table"].load_tracks.assert_called_once_with([])
-    msgs = [c.args[0] for c in widgets["#recent-loading"].update.call_args_list]
-    assert any("Sign in to YT Music" in m for m in msgs), msgs
+    assert any("Sign in to YT Music" in m for m in _loading_messages(widgets))
 
 
-# ── Local loader still honours the cap ───────────────────────────────
+async def test_ytm_fetch_puts_pending_accepted_plays_ahead_of_the_feed(monkeypatch) -> None:
+    page, widgets = _make_page(active_tab=_TAB_YTM)
+    fake_app = _fake_app(feed=_raw_tracks(3))
+    fake_app._ytm_history_pending = [{"video_id": "vid0001", "title": "Accepted"}]
+    _attach_fake_app(page, fake_app, monkeypatch)
+
+    await page._load_ytm_history()
+
+    assert _ids(fake_app._ytm_history) == ["vid0001", "vid0000", "vid0002"]
+    assert fake_app._ytm_history[0]["title"] == "Accepted"
+    assert fake_app._ytm_history_pending == []
 
 
-async def test_local_tab_requests_max_tracks(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_ytm_fetch_in_flight_cannot_hide_a_newer_accepted_play(monkeypatch) -> None:
+    """A report the account accepts while get_history() is still running is
+    parked as pending; the older fetch merges it in instead of overwriting."""
+    page, widgets = _make_page(active_tab=_TAB_YTM)
+    release = asyncio.Event()
+
+    async def slow_history():
+        await release.wait()
+        return _raw_tracks(2)
+
+    fake_app = _fake_app()
+    fake_app.ytmusic.get_history = AsyncMock(side_effect=slow_history)
+    _attach_fake_app(page, fake_app, monkeypatch)
+
+    fetch = asyncio.create_task(page._load_ytm_history())
+    await asyncio.sleep(0)  # the fetch is now waiting on get_history()
+    fake_app._ytm_history_pending.append({"video_id": "new", "title": "Just played"})
+    release.set()
+    await fetch
+
+    assert _ids(fake_app._ytm_history) == ["new", "vid0000", "vid0001"]
+    assert _ids(_loaded(widgets)) == ["new", "vid0000", "vid0001"]
+
+
+# ── Local loader ─────────────────────────────────────────────────────
+
+
+async def test_local_tab_requests_max_tracks(monkeypatch) -> None:
     page, widgets = _make_page(active_tab=_TAB_LOCAL)
-
-    fake_history = MagicMock()
-    fake_history.get_recently_played = AsyncMock(return_value=_raw_tracks(10))
-    fake_app = MagicMock()
-    fake_app.history = fake_history
+    fake_app = _fake_app(local=_local_rows(10))
     _attach_fake_app(page, fake_app, monkeypatch)
 
     await page._load_history()
 
-    fake_history.get_recently_played.assert_awaited_once_with(limit=_MAX_TRACKS)
+    fake_app.history.get_recently_played.assert_awaited_once_with(limit=_MAX_TRACKS)
+    assert len(_loaded(widgets)) == 10
 
 
-# ── Optimistic add ───────────────────────────────────────────────────
+# ── All: composition ─────────────────────────────────────────────────
 
 
-async def test_optimistic_add_prepends_dedups_and_rerenders(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A just-played track is prepended to the tab cache (deduped) and the
-    Local tab re-renders live, matching the YT Music behaviour."""
-    page, widgets = _make_page(active_tab=_TAB_LOCAL)
-    fake_app = MagicMock()
-    _attach_fake_app(page, fake_app, monkeypatch)
-
-    page._tab_cache[_TAB_LOCAL] = [
-        {"video_id": "a"},
-        {"video_id": "vid1"},
-        {"video_id": "b"},
+def test_compose_all_is_local_first_then_account_only_in_server_order() -> None:
+    local = _local_rows(2)
+    account = [
+        {"video_id": "acc0", "title": "A0"},
+        {"video_id": "loc0001", "title": "Server copy"},
+        {"video_id": "acc1", "title": "A1"},
     ]
 
-    page.optimistic_add(_TAB_LOCAL, {"video_id": "vid1", "title": "X"})
+    rows = _compose_all(local, account)
 
-    ids = [t["video_id"] for t in page._tab_cache[_TAB_LOCAL]]
-    assert ids == ["vid1", "a", "b"]
-    widgets["#recent-table"].load_tracks.assert_called_once()
+    assert _ids(rows) == ["loc0000", "loc0001", "acc0", "acc1"]
 
 
-def test_optimistic_add_noop_without_cache(monkeypatch: pytest.MonkeyPatch) -> None:
-    page, widgets = _make_page(active_tab=_TAB_LOCAL)
-    fake_app = MagicMock()
+def test_compose_all_overlap_keeps_local_row_and_fills_missing_metadata() -> None:
+    local = _local_rows(1)
+    account = [
+        {
+            "video_id": "loc0000",
+            "title": "Server title",
+            "artist": "Server artist",
+            "artists": [{"name": "Artist", "id": "A1"}],
+            "album_id": "AL1",
+            "duration": 200,
+            "thumbnail_url": "https://img/x.jpg",
+            "is_video": False,
+        }
+    ]
+
+    (row,) = _compose_all(local, account)
+
+    # Local values win and the local timestamp survives...
+    assert row["title"] == "Local 0"
+    assert row["artist"] == "Artist"
+    assert row["played_at"] == local[0]["played_at"]
+    assert row["duration_seconds"] == 180
+    # ...while fields the local row lacks come from the account row.
+    assert row["artists"] == [{"name": "Artist", "id": "A1"}]
+    assert row["album_id"] == "AL1"
+    assert row["thumbnail_url"] == "https://img/x.jpg"
+    assert row["duration"] == 200
+    assert row["is_video"] is False
+
+
+def test_compose_all_dedups_before_the_account_only_cap() -> None:
+    """100 local rows all present in a 200-row feed: All is 100 local plus the
+    100 account-only rows, not 100 local plus nothing."""
+    local = _local_rows(_MAX_TRACKS)
+    account = [{"video_id": t["video_id"]} for t in local] + [
+        {"video_id": f"acc{i:04d}"} for i in range(_MAX_TRACKS)
+    ]
+
+    rows = _compose_all(local, account)
+
+    assert len(rows) == 2 * _MAX_TRACKS
+    assert _ids(rows[:_MAX_TRACKS]) == _ids(local)
+    assert _ids(rows[_MAX_TRACKS:]) == [f"acc{i:04d}" for i in range(_MAX_TRACKS)]
+
+
+def test_compose_all_caps_each_source_separately() -> None:
+    local = _local_rows(_MAX_TRACKS + 20)
+    account = [{"video_id": f"acc{i:04d}"} for i in range(_MAX_TRACKS + 30)]
+
+    rows = _compose_all(local, account)
+
+    assert _ids(rows[:_MAX_TRACKS]) == _ids(local[:_MAX_TRACKS])
+    assert len(rows) == 2 * _MAX_TRACKS
+    assert rows[-1]["video_id"] == f"acc{_MAX_TRACKS - 1:04d}"
+
+
+def test_compose_all_with_one_source_empty() -> None:
+    assert _ids(_compose_all(_local_rows(2), [])) == ["loc0000", "loc0001"]
+    assert _ids(_compose_all([], [{"video_id": "a"}, {"video_id": "b"}])) == ["a", "b"]
+    assert _compose_all([], []) == []
+
+
+# ── All: loading and partial results ─────────────────────────────────
+
+
+async def test_all_tab_loads_both_sources_and_renders_grouped_rows(monkeypatch) -> None:
+    page, widgets = _make_page(active_tab=_TAB_ALL)
+    feed = _raw_tracks(2, prefix="acc") + [{**_raw_tracks(1)[0], "videoId": "loc0001"}]
+    fake_app = _fake_app(local=_local_rows(3), feed=feed)
     _attach_fake_app(page, fake_app, monkeypatch)
 
-    page.optimistic_add(_TAB_LOCAL, {"video_id": "vid1"})
+    await page._load_all()
 
-    assert _TAB_LOCAL not in page._tab_cache
+    assert _ids(_loaded(widgets)) == ["loc0000", "loc0001", "loc0002", "acc0000", "acc0001"]
+    assert "local history first" in _footer(widgets)
+    assert "couldn't be loaded" not in _footer(widgets)
+    assert page._get_cache(_TAB_LOCAL) is not None
+    assert fake_app._ytm_history is not None and len(fake_app._ytm_history) == 3
+
+
+async def test_all_tab_shows_local_only_with_a_note_when_ytm_fails(monkeypatch) -> None:
+    page, widgets = _make_page(active_tab=_TAB_ALL)
+    fake_app = _fake_app(local=_local_rows(2), feed=None)
+    _attach_fake_app(page, fake_app, monkeypatch)
+
+    await page._load_all()
+
+    assert _ids(_loaded(widgets)) == ["loc0000", "loc0001"]
+    assert "YT Music history couldn't be loaded" in _footer(widgets)
+    assert fake_app._ytm_history is None
+
+
+async def test_all_tab_shows_account_only_with_a_note_when_local_fails(monkeypatch) -> None:
+    page, widgets = _make_page(active_tab=_TAB_ALL)
+    fake_app = _fake_app(local_error=OSError("disk full"), feed=_raw_tracks(2))
+    _attach_fake_app(page, fake_app, monkeypatch)
+
+    await page._load_all()
+
+    assert _ids(_loaded(widgets)) == ["vid0000", "vid0001"]
+    assert "local history couldn't be loaded" in _footer(widgets)
+    assert page._get_cache(_TAB_LOCAL) is None
+
+
+async def test_all_tab_without_a_service_shows_local_with_a_sign_in_note(monkeypatch) -> None:
+    page, widgets = _make_page(active_tab=_TAB_ALL)
+    _attach_fake_app(page, _fake_app(local=_local_rows(2), ytmusic=False), monkeypatch)
+
+    await page._load_all()
+
+    assert _ids(_loaded(widgets)) == ["loc0000", "loc0001"]
+    assert "sign in to YT Music" in _footer(widgets)
+
+
+async def test_all_tab_says_which_sources_failed_when_nothing_loads(monkeypatch) -> None:
+    page, widgets = _make_page(active_tab=_TAB_ALL)
+    _attach_fake_app(page, _fake_app(local_error=OSError("locked"), feed=None), monkeypatch)
+
+    await page._load_all()
+
+    widgets["#recent-table"].load_tracks.assert_called_once_with([])
+    message = _loading_messages(widgets)[-1]
+    assert "Couldn't load local history" in message
+    assert "couldn't load YT Music history" in message
+    assert "Start listening" not in message
+
+
+async def test_all_tab_genuinely_empty_shows_empty_state(monkeypatch) -> None:
+    page, widgets = _make_page(active_tab=_TAB_ALL)
+    _attach_fake_app(page, _fake_app(local=[], feed=[]), monkeypatch)
+
+    await page._load_all()
+
+    assert "No play history yet" in _loading_messages(widgets)[-1]
+
+
+async def test_all_loader_does_not_render_after_the_user_switched_tab(monkeypatch) -> None:
+    page, widgets = _make_page(active_tab=_TAB_ALL)
+    release = asyncio.Event()
+
+    async def slow_history():
+        await release.wait()
+        return _raw_tracks(2)
+
+    fake_app = _fake_app(local=_local_rows(1))
+    fake_app.ytmusic.get_history = AsyncMock(side_effect=slow_history)
+    _attach_fake_app(page, fake_app, monkeypatch)
+
+    load = asyncio.create_task(page._load_all())
+    await asyncio.sleep(0)
+    page._active_tab = _TAB_LOCAL  # the user moved on while the fetch was in flight
+    release.set()
+    await load
+
     widgets["#recent-table"].load_tracks.assert_not_called()
+    assert fake_app._ytm_history is not None  # the fetch itself still fills the cache
 
 
-# ── Keyboard tab switching ───────────────────────────────────────────
+# ── Default tab and navigation state ─────────────────────────────────
 
 
-async def test_enter_on_focused_tab_switches(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_all_is_the_default_tab() -> None:
+    assert _DEFAULT_TAB == _TAB_ALL
+    assert RecentlyPlayedPage()._active_tab == _TAB_ALL
+    assert RecentlyPlayedPage(active_tab=99)._active_tab == _TAB_ALL
+
+
+def test_nav_state_stores_non_default_tab_and_cursor() -> None:
+    page, widgets = _make_page(active_tab=_TAB_YTM)
+    widgets["#recent-table"].cursor_row = 4
+    assert page.get_nav_state() == {"active_tab": _TAB_YTM, "cursor_row": 4}
+
+    page, widgets = _make_page(active_tab=_TAB_ALL)
+    widgets["#recent-table"].cursor_row = 0
+    assert page.get_nav_state() == {}
+
+
+def test_nav_state_restores_tab_and_cursor() -> None:
+    page = RecentlyPlayedPage(active_tab=_TAB_LOCAL, cursor_row=3)
+    assert page._active_tab == _TAB_LOCAL
+    page, widgets = _make_page(active_tab=_TAB_LOCAL)
+    page._restore_cursor_row = 3
+    widgets["#recent-table"].row_count = 5
+
+    page._display_tracks(_local_rows(5))
+
+    widgets["#recent-table"].move_cursor.assert_called_once_with(row=3)
+
+
+# ── Tab switching ────────────────────────────────────────────────────
+
+
+def test_switch_tab_updates_labels_and_description(monkeypatch) -> None:
+    page, widgets = _make_page(active_tab=_TAB_ALL)
+    fake_app = _fake_app()
+    _attach_fake_app(page, fake_app, monkeypatch)
+    monkeypatch.setattr(page, "_load_active_tab", MagicMock())
+
+    page._switch_tab(_TAB_LOCAL)
+
+    widgets["#recent-tab-all"].set_class.assert_called_once_with(False, "active")
+    widgets["#recent-tab-local"].set_class.assert_called_once_with(True, "active")
+    widgets["#recent-tab-ytm"].set_class.assert_called_once_with(False, "active")
+    widgets["#recent-tab-desc"].update.assert_called_once_with(_TAB_DESCRIPTIONS[_TAB_LOCAL])
+    page._load_active_tab.assert_called_once()
+
+
+def test_switch_to_all_with_both_sources_cached_renders_without_fetching(monkeypatch) -> None:
+    page, widgets = _make_page(active_tab=_TAB_LOCAL)
+    fake_app = _fake_app()
+    fake_app._ytm_history = [{"video_id": "acc0"}]
+    _attach_fake_app(page, fake_app, monkeypatch)
+    page._set_cache(_TAB_LOCAL, _local_rows(1))
+    monkeypatch.setattr(page, "_load_active_tab", MagicMock())
+
+    page._switch_tab(_TAB_ALL)
+
+    assert _ids(_loaded(widgets)) == ["loc0000", "acc0"]
+    page._load_active_tab.assert_not_called()
+
+
+def test_switch_to_all_with_one_source_missing_loads(monkeypatch) -> None:
+    page, widgets = _make_page(active_tab=_TAB_LOCAL)
+    _attach_fake_app(page, _fake_app(), monkeypatch)  # account cache None
+    page._set_cache(_TAB_LOCAL, _local_rows(1))
+    monkeypatch.setattr(page, "_load_active_tab", MagicMock())
+
+    page._switch_tab(_TAB_ALL)
+
+    widgets["#recent-table"].load_tracks.assert_not_called()
+    page._load_active_tab.assert_called_once()
+
+
+def test_reselecting_all_drops_both_caches_and_reloads(monkeypatch) -> None:
+    page, _ = _make_page(active_tab=_TAB_ALL)
+    fake_app = _fake_app()
+    fake_app._ytm_history = _raw_tracks(3)
+    _attach_fake_app(page, fake_app, monkeypatch)
+    page._set_cache(_TAB_LOCAL, _local_rows(2))
+    monkeypatch.setattr(page, "_load_active_tab", MagicMock())
+
+    page._switch_tab(_TAB_ALL)  # same tab → refresh
+
+    assert fake_app._ytm_history is None
+    assert page._get_cache(_TAB_LOCAL) is None
+    page._load_active_tab.assert_called_once()
+    fake_app.notify.assert_called_once()
+
+
+def test_reselecting_active_tab_reloads(monkeypatch) -> None:
+    """Clicking / Enter on the already-active tab drops its cache and
+    refetches, so the YT Music tab can be refreshed without leaving."""
+    page, _ = _make_page(active_tab=_TAB_YTM)
+    fake_app = _fake_app()
+    fake_app._ytm_history = _raw_tracks(3)
+    _attach_fake_app(page, fake_app, monkeypatch)
+    monkeypatch.setattr(page, "_load_active_tab", MagicMock())
+
+    page._switch_tab(_TAB_YTM)
+
+    assert fake_app._ytm_history is None
+    page._load_active_tab.assert_called_once()
+    fake_app.notify.assert_called_once()
+
+
+async def test_enter_on_focused_tab_switches(monkeypatch) -> None:
     """With a tab label focused, SELECT (Enter) switches to that tab."""
     page, widgets = _make_page(active_tab=_TAB_LOCAL)
-
     focused_tab = RecentTab("YT Music", _TAB_YTM, id="recent-tab-ytm")
-    fake_app = MagicMock()
+    fake_app = _fake_app()
     fake_app.focused = focused_tab
-    # Pre-seed the app-level YT Music cache so the switch takes the
-    # no-refetch path.
-    fake_app._ytm_history = _raw_tracks(3)
+    fake_app._ytm_history = _raw_tracks(3)  # cached → no refetch
     _attach_fake_app(page, fake_app, monkeypatch)
 
     await page.handle_action(Action.SELECT)
@@ -298,98 +531,142 @@ async def test_enter_on_focused_tab_switches(monkeypatch: pytest.MonkeyPatch) ->
     widgets["#recent-table"].load_tracks.assert_called_once()
 
 
-async def test_movement_on_focused_tab_drops_into_table(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """j/k while a tab is focused should move focus into the table, not
-    switch tabs."""
+async def test_movement_on_focused_tab_drops_into_table(monkeypatch) -> None:
     page, widgets = _make_page(active_tab=_TAB_LOCAL)
-
-    focused_tab = RecentTab("YT Music", _TAB_YTM, id="recent-tab-ytm")
-    fake_app = MagicMock()
-    fake_app.focused = focused_tab
+    fake_app = _fake_app()
+    fake_app.focused = RecentTab("Local", _TAB_LOCAL, id="recent-tab-local")
     _attach_fake_app(page, fake_app, monkeypatch)
 
     await page.handle_action(Action.MOVE_DOWN)
 
-    assert page._active_tab == _TAB_LOCAL
     widgets["#recent-table"].focus.assert_called_once()
+    widgets["#recent-table"].handle_action.assert_not_called()
 
 
-def test_reselecting_active_tab_reloads(monkeypatch) -> None:
-    """Clicking / Enter on the already-active tab drops its cache and
-    refetches, so the YT Music tab can be refreshed without leaving."""
-    page, _ = _make_page(active_tab=_TAB_YTM)
-
-    fake_app = MagicMock()
-    fake_app._ytm_history = _raw_tracks(3)
-    _attach_fake_app(page, fake_app, monkeypatch)
-    monkeypatch.setattr(page, "_load_active_tab", MagicMock())
-
-    page._switch_tab(_TAB_YTM)  # same tab → refresh
-
-    assert fake_app._ytm_history is None
-    page._load_active_tab.assert_called_once()
-    fake_app.notify.assert_called_once()
+# ── Live updates ─────────────────────────────────────────────────────
 
 
-# ── background refresh (focus / filter / cursor) ─────────────────────
-
-
-def _page_with_cache(monkeypatch, tracks):
-    page, widgets = _make_page(active_tab=_TAB_LOCAL)
-    fake_app = MagicMock()
+def _page_with_cache(monkeypatch, tracks, active_tab=_TAB_LOCAL):
+    page, widgets = _make_page(active_tab=active_tab)
+    fake_app = _fake_app()
     _attach_fake_app(page, fake_app, monkeypatch)
     page._set_cache(_TAB_LOCAL, tracks)
-    return page, widgets
+    return page, widgets, fake_app
+
+
+def test_optimistic_add_prepends_dedups_and_rerenders(monkeypatch) -> None:
+    page, widgets, _ = _page_with_cache(
+        monkeypatch, [{"video_id": "a"}, {"video_id": "vid1"}, {"video_id": "b"}]
+    )
+
+    page.optimistic_add(_TAB_LOCAL, {"video_id": "vid1", "title": "X"})
+
+    assert _ids(page._tab_cache[_TAB_LOCAL]) == ["vid1", "a", "b"]
+    widgets["#recent-table"].load_tracks.assert_called_once()
+
+
+def test_optimistic_add_noop_without_cache(monkeypatch) -> None:
+    page, widgets = _make_page(active_tab=_TAB_LOCAL)
+    _attach_fake_app(page, _fake_app(), monkeypatch)
+
+    page.optimistic_add(_TAB_LOCAL, {"video_id": "vid1"})
+
+    assert _TAB_LOCAL not in page._tab_cache
+    widgets["#recent-table"].load_tracks.assert_not_called()
+
+
+def test_optimistic_add_caps_local_but_not_the_account_cache(monkeypatch) -> None:
+    page, widgets = _make_page(active_tab=_TAB_YTM)
+    fake_app = _fake_app()
+    fake_app._ytm_history = [{"video_id": f"acc{i:04d}"} for i in range(_MAX_TRACKS)]
+    _attach_fake_app(page, fake_app, monkeypatch)
+    page._set_cache(_TAB_LOCAL, [{"video_id": f"loc{i:04d}"} for i in range(_MAX_TRACKS)])
+
+    page.optimistic_add(_TAB_LOCAL, {"video_id": "newloc"})
+    page.optimistic_add(_TAB_YTM, {"video_id": "newacc"})
+
+    assert len(page._tab_cache[_TAB_LOCAL]) == _MAX_TRACKS
+    assert len(fake_app._ytm_history) == _MAX_TRACKS + 1
+    assert len(_loaded(widgets)) == _MAX_TRACKS  # the view still caps
+    assert _loaded(widgets)[0]["video_id"] == "newacc"
+
+
+def test_local_play_rerenders_all_while_it_is_showing(monkeypatch) -> None:
+    page, widgets, fake_app = _page_with_cache(monkeypatch, [{"video_id": "a"}], _TAB_ALL)
+    fake_app._ytm_history = [{"video_id": "b"}]
+
+    page.optimistic_add(_TAB_LOCAL, {"video_id": "c"})
+
+    assert _ids(_loaded(widgets)) == ["c", "a", "b"]
+    assert widgets["#recent-table"].focus.call_count == 0  # background refresh
+
+
+def test_accepted_account_play_rerenders_all_while_it_is_showing(monkeypatch) -> None:
+    page, widgets, fake_app = _page_with_cache(monkeypatch, [{"video_id": "a"}], _TAB_ALL)
+    fake_app._ytm_history = [{"video_id": "new"}, {"video_id": "b"}]  # the app prepended "new"
+
+    page._refresh_tab_from_cache(_TAB_YTM)
+
+    assert _ids(_loaded(widgets)) == ["a", "new", "b"]
+
+
+def test_background_update_of_another_tab_does_not_render(monkeypatch) -> None:
+    page, widgets, fake_app = _page_with_cache(monkeypatch, [{"video_id": "a"}], _TAB_LOCAL)
+    fake_app._ytm_history = [{"video_id": "b"}]
+
+    page._refresh_tab_from_cache(_TAB_YTM)
+
+    widgets["#recent-table"].load_tracks.assert_not_called()
 
 
 def test_background_refresh_does_not_steal_focus(monkeypatch) -> None:
-    page, widgets = _page_with_cache(monkeypatch, [{"video_id": "a", "title": "A"}])
-    widgets["#recent-table"].tracks = []
+    page, widgets, _ = _page_with_cache(monkeypatch, [{"video_id": "a"}])
 
     page._refresh_tab_from_cache(_TAB_LOCAL)
 
+    widgets["#recent-table"].load_tracks.assert_called_once()
     widgets["#recent-table"].focus.assert_not_called()
 
 
 def test_initial_display_still_focuses_table(monkeypatch) -> None:
-    page, widgets = _make_page(active_tab=_TAB_LOCAL)
-    fake_app = MagicMock()
-    _attach_fake_app(page, fake_app, monkeypatch)
-    widgets["#recent-table"].row_count = 1
+    page, widgets, _ = _page_with_cache(monkeypatch, [{"video_id": "a"}])
 
-    page._display_tracks([{"video_id": "a", "title": "A"}])
+    page._display_tracks([{"video_id": "a"}])
 
     widgets["#recent-table"].focus.assert_called_once()
 
 
 def test_background_refresh_reapplies_active_filter(monkeypatch) -> None:
-    page, widgets = _page_with_cache(
-        monkeypatch,
-        [{"video_id": "a", "title": "Alpha"}, {"video_id": "b", "title": "Beta"}],
-    )
-    widgets["#track-filter"].value = "alp"
-    widgets["#recent-table"].tracks = []
+    page, widgets, _ = _page_with_cache(monkeypatch, [{"video_id": "a"}])
+    widgets["#track-filter"].value = "abc"
 
     page._refresh_tab_from_cache(_TAB_LOCAL)
 
-    widgets["#recent-table"].load_tracks.assert_called_once()
-    widgets["#recent-table"].apply_filter.assert_called_once_with("alp")
+    widgets["#recent-table"].apply_filter.assert_called_once_with("abc")
+
+
+def test_background_refresh_keeps_cursor_on_same_track(monkeypatch) -> None:
+    """A dedup-move refresh is net-zero: the cursored track keeps its row.
+    Identity comes from ``selected_track`` (the highlighted VISIBLE row,
+    mapped through any active sort) — a backing-list index would restore
+    to the wrong track in a sorted view.
+    """
+    new = [{"video_id": "b", "title": "B"}, {"video_id": "a", "title": "A"}]
+    page, widgets, _ = _page_with_cache(monkeypatch, new)
+    widgets["#recent-table"].selected_track = {"video_id": "a", "title": "A"}
+    widgets["#recent-table"].row_count = 2
+
+    page._refresh_tab_from_cache(_TAB_LOCAL)
+
+    widgets["#recent-table"].move_cursor.assert_called_once_with(row=1)
+
+
+# ── Failure flags stay per source ────────────────────────────────────
 
 
 async def test_local_failure_does_not_leak_onto_ytm_tab(monkeypatch) -> None:
-    """A failed Local load then a YTM visit with 0 rows must show the YTM
-    empty message, not the local-failure copy."""
     page, widgets = _make_page(active_tab=_TAB_LOCAL)
-    fake_app = MagicMock()
-    fake_app.history.get_recently_played = AsyncMock(side_effect=OSError("locked"))
-    fake_app.history.get_played_video_ids = AsyncMock(return_value=set())
-    fake_ytmusic = MagicMock()
-    fake_ytmusic.get_history = AsyncMock(return_value=[])
-    fake_app.ytmusic = fake_ytmusic
-    fake_app._ytm_history = None
-    _attach_fake_app(page, fake_app, monkeypatch)
+    _attach_fake_app(page, _fake_app(local_error=OSError("locked"), feed=[]), monkeypatch)
 
     await page._load_history()
     assert page._load_failed is True
@@ -397,41 +674,15 @@ async def test_local_failure_does_not_leak_onto_ytm_tab(monkeypatch) -> None:
     page._active_tab = _TAB_YTM
     await page._load_ytm_history()
 
-    msg = str(widgets["#recent-loading"].update.call_args.args[0])
-    assert "No YT Music play history found." in msg
-    # The local flag survives for the local tab's own retry logic.
-    assert page._load_failed is True
+    assert "No YT Music play history found." in _loading_messages(widgets)[-1]
+    assert page._load_failed is True  # survives for the local tab's own retry logic
 
 
 async def test_ytm_visit_does_not_clear_local_failure_flag(monkeypatch) -> None:
     page, widgets = _make_page(active_tab=_TAB_YTM)
-    fake_ytmusic = MagicMock()
-    fake_ytmusic.get_history = AsyncMock(return_value=_raw_tracks(3))
-    fake_app = MagicMock()
-    fake_app.ytmusic = fake_ytmusic
-    fake_app._ytm_history = None
-    fake_app.history.get_played_video_ids = AsyncMock(return_value=set())
-    _attach_fake_app(page, fake_app, monkeypatch)
-    page._load_failed = True  # local tab failed earlier
+    _attach_fake_app(page, _fake_app(feed=_raw_tracks(3)), monkeypatch)
+    page._load_failed = True
 
     await page._load_ytm_history()
 
     assert page._load_failed is True
-
-
-def test_background_refresh_keeps_cursor_on_same_track(monkeypatch) -> None:
-    """A dedup-move refresh is net-zero: the cursored track keeps its row.
-
-    Identity comes from ``selected_track`` (the highlighted VISIBLE row,
-    mapped through any active sort) — a backing-list index would restore
-    to the wrong track in a sorted view.
-    """
-    new = [{"video_id": "b", "title": "B"}, {"video_id": "a", "title": "A"}]
-    page, widgets = _page_with_cache(monkeypatch, new)
-    widgets["#recent-table"].selected_track = {"video_id": "a", "title": "A"}
-    widgets["#recent-table"].row_count = 2
-
-    page._refresh_tab_from_cache(_TAB_LOCAL)
-
-    # "a" is at index 1 in the new cache; move_cursor lands there.
-    widgets["#recent-table"].move_cursor.assert_called_once_with(row=1)


### PR DESCRIPTION
Closes #115

The Recently Played page now has three tabs: **All** (default), **Local** and **YT Music**. A line under the tab row says what the active tab shows.

- **YT Music** shows the first 100 entries from the account history returned by YouTube Music, without excluding locally played tracks. Until now every track ever played in this app was filtered out of it; this also hid tracks subsequently played on other devices, so it represented neither complete account history nor reliable other-device history.
- **All** shows local history first, followed by additional account history: up to 100 local rows, then up to 100 account-only rows in server order, one row per track. A track played both here and elsewhere keeps its local position and time, with the fields the local row lacks (artist and album IDs, artwork) filled in from the account row. It is two groups, not one timeline, and the page says so.
- **Local** is the previous local tab, unchanged: tracks played in this app, most recent first, up to 100.

If one source can't be loaded, All shows the other and the footer says which one is missing, notice first, so it is readable at 80 columns. Re-selecting the active tab refreshes it; refreshing All refetches both sources.

Playback reporting is unchanged (same default, same listen threshold). A play the account accepts appears on the YT Music and All tabs right away; a play the account rejects leaves them untouched. A fetch that started before an accepted play cannot hide it, and a play accepted before a fetch started keeps its position in the feed that fetch returns.

Verification: 1,639 passed, 1 skipped on Python 3.11 and 3.14; Ruff lint/format clean; independently reviewed at 78fbe4f. The rendered-width test mounts the real page headless and reads back the painted lines at 80, 100 and 120 columns.

Thanks @Villoh for the tabs and the discussion.
