### PR TITLE
fix(auth): update the sign-in files as one guarded transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 **Fixes**
 
+- **Sign-in files are updated in one guarded step** — `auth.json` is replaced atomically, its account record is written for exactly those bytes, and an automatic renewal only replaces the session it started from: a newer `ytm setup` is never overwritten or rolled back by a renewal, and two `ytm` processes can no longer update the sign-in at the same time. A crash between the writes leaves a working session that needs `ytm setup` to renew automatically again, never a truncated file.
+- **Stream cookies are used only when they belong to the current sign-in** — with `[yt_dlp] use_session_cookies` on, the saved stream cookie file is loaded only if the sign-in record vouches for it; otherwise streaming continues without session cookies and the log says to run `ytm setup`.
+- **`ytm setup --manual` keeps the existing account record until the pasted headers are accepted**, records a pasted session it could not verify as such, and refuses to write through a symlink at `auth.json`.
+- **`ytm setup` says when ytm is running** and that it needs a restart to use the new sign-in.
 - **Downloaded audio is indexed for playback** — files already in the configured cache directory are no longer copied onto themselves. Retrying Download repairs an existing unindexed file without downloading it again, and indexing failures are reported.
 - **Cancelled downloads retain their writer until completion** — retries cannot start another writer for the same track while yt-dlp is still running. New downloads publish their final cache file only after downloading and postprocessing succeed, so failed conversion output cannot be reused as a completed download.
 - **Downloads count toward the cache limit** — a downloaded track is a cache entry like any other: it counts toward `[cache] max_size_mb` and is removed least-recently-accessed when the limit is reached. A download that doesn't fit within the limit is reported as "Not retained in cache" instead of "Downloaded". A download interrupted by the app being killed starts again from the beginning.

--- a/src/ytm_player/cli.py
+++ b/src/ytm_player/cli.py
@@ -37,7 +37,7 @@ from ytm_player.config.paths import (
     ensure_dirs,
 )
 from ytm_player.config.settings import get_settings
-from ytm_player.ipc import ipc_request, is_tui_running, try_claim_pid
+from ytm_player.ipc import get_running_pid, ipc_request, is_tui_running, try_claim_pid
 from ytm_player.services.auth import AuthManager
 from ytm_player.utils.logging import install_excepthooks, setup_logging
 
@@ -224,6 +224,12 @@ def main(ctx: click.Context, compact_json: bool, debug: bool) -> None:
 def setup(manual: bool, browser: str | None) -> None:
     """Interactive authentication wizard for YouTube Music."""
     auth = AuthManager(cookies_file=get_settings().yt_dlp.cookies_file)
+
+    running = get_running_pid()
+    if running is not None:
+        click.echo(
+            f"ytm is running (PID {running}). Restart it after setup so it uses the new sign-in."
+        )
 
     if auth.is_authenticated():
         click.echo("Existing authentication found.")

--- a/src/ytm_player/services/auth.py
+++ b/src/ytm_player/services/auth.py
@@ -5,21 +5,26 @@ Brave, Helium, etc.) using yt-dlp's cookie extraction. Falls back to manual
 header paste if auto-extraction fails.
 
 Also writes a separate, wider-scoped (youtube.com+google.com) cookiejar file
-consumed by stream.py's yt-dlp resolver — see _save_stream_cookiejar().
+consumed by stream.py's yt-dlp resolver — see _build_stream_cookiejar() and
+read_vouched_stream_jar().
 """
 
 from __future__ import annotations
 
+import errno
 import hashlib
+import io
 import json
 import logging
 import os
 import re
+import stat
 import sys
 import tempfile
+import threading
 import time
 from collections.abc import Callable, Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from http.cookiejar import Cookie, MozillaCookieJar
 from pathlib import Path
 from typing import IO, Any
@@ -135,36 +140,299 @@ def _atomic_write(
     write: Callable[[IO[Any]], None],
     encoding: str | None = None,
 ) -> None:
-    """Write *path* atomically via an O_NOFOLLOW temp file + os.replace.
+    """Replace *path* atomically through a temp file this call created.
 
-    Shared by AuthManager._restore_or_remove and
-    AuthManager._save_stream_cookiejar, the two sites that need
-    atomic-replace semantics for a security-sensitive file: open a
-    PID-suffixed temp file with O_NOFOLLOW (refusing to follow a symlink
-    planted at the temp path), let *write* fill it via the fd opened in
-    *mode* (and *encoding*, for text mode), chmod it to SECURE_FILE_MODE,
-    then os.replace() it into place.
+    The temp file is opened O_CREAT | O_EXCL (plus O_NOFOLLOW where the
+    platform has it) under a random name, so on every platform — Windows
+    included — it is a file of our own: never an existing entry, never a
+    planted symlink written through. *write* fills it via the fd opened in
+    *mode* (and *encoding*, for text mode); it is chmod'ed to
+    SECURE_FILE_MODE and then os.replace()d into place.
 
-    *write* owns the actual content — a raw bytes write, a cookiejar's
-    .save(), etc. — so this helper stays agnostic to what's being written.
-    On any failure the temp file is removed and the exception re-raised;
-    callers decide what to catch and how to log, since they disagree on
-    which exceptions are recoverable (OSError only vs. broad Exception).
+    Symlink at the destination: one that is already there is refused
+    (OSError ELOOP) and left alone. os.replace() never writes through a
+    link, so the target of a link planted between that check and the
+    replace is untouched as well — the link entry itself is replaced by the
+    file. The guarantee is "a symlink's target is never overwritten", not
+    "a planted link always survives".
+
+    On any failure only the temp file this call created is removed and the
+    exception re-raised; callers decide what to catch and how to log.
     """
-    tmp_path = path.with_name(f"{path.name}.tmp-{os.getpid()}")
+    tmp_path = path.with_name(f"{path.name}.tmp-{os.getpid()}-{os.urandom(4).hex()}")
+    created = False
     try:
         fd = os.open(
             str(tmp_path),
-            os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
             SECURE_FILE_MODE,
         )
+        created = True
         with os.fdopen(fd, mode, encoding=encoding) as f:
             write(f)
         secure_chmod(tmp_path, SECURE_FILE_MODE)
+        if _is_symlink(path):
+            raise OSError(errno.ELOOP, "refusing to replace a symlink", str(path))
         os.replace(tmp_path, path)
     except Exception:
-        tmp_path.unlink(missing_ok=True)
+        if created:
+            tmp_path.unlink(missing_ok=True)
         raise
+
+
+def _is_symlink(path: Path) -> bool:
+    """lstat-based check; on Windows this also reports reparse-point links."""
+    try:
+        return stat.S_ISLNK(os.lstat(path).st_mode)
+    except FileNotFoundError:
+        return False
+
+
+class SessionError(RuntimeError):
+    """A sign-in file operation could not complete safely.
+
+    Deliberately NOT an OSError: this module's auth-file fallbacks and read
+    guards catch OSError, and none of them may absorb one of these.
+    """
+
+
+class SessionBusyError(SessionError):
+    """auth.json / account.json are mid-replacement by another writer."""
+
+
+class SessionLockTimeoutError(SessionError):
+    """Another ytm thread or process held the sign-in lock for the whole wait."""
+
+
+class SessionUnreadableError(SessionError):
+    """account.json exists but cannot be read: the session cannot be
+    classified, so no client is built from it (an unreadable record is
+    never treated as an absent one)."""
+
+
+_LOCK_TIMEOUT_SECONDS = 30.0
+_LOCK_POLL_SECONDS = 0.05
+
+
+@dataclass
+class _PathLock:
+    """In-process half of the sign-in lock for one lock-file path."""
+
+    mutex: threading.Lock = field(default_factory=threading.Lock)
+    owner: int | None = None  # threading.get_ident() of the holder
+
+
+_PATH_LOCKS: dict[str, _PathLock] = {}
+_PATH_LOCKS_GUARD = threading.Lock()
+
+
+def _path_lock(lock_path: Path) -> _PathLock:
+    """The one _PathLock for *lock_path*, shared by every AuthManager in the process."""
+    key = os.path.normcase(os.path.abspath(lock_path))
+    with _PATH_LOCKS_GUARD:
+        return _PATH_LOCKS.setdefault(key, _PathLock())
+
+
+def _open_lock_file(lock_path: Path) -> int:
+    """Open the lock file (creating it 0600 if needed), refusing a symlink or
+    reparse point at its path on every platform. O_NOFOLLOW closes the
+    check→open gap where the platform has it; on Windows that gap remains
+    and the worst case is a one-byte range lock on the link's target."""
+    if _is_symlink(lock_path):
+        raise OSError(errno.ELOOP, "refusing to lock through a symlink", str(lock_path))
+    fd = os.open(
+        str(lock_path),
+        os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
+        SECURE_FILE_MODE,
+    )
+    try:
+        if sys.platform != "win32":
+            os.fchmod(fd, SECURE_FILE_MODE)
+    except OSError:
+        os.close(fd)
+        raise
+    return fd
+
+
+def _try_os_lock(fd: int) -> bool:
+    """One non-blocking attempt at the OS-level exclusive lock on *fd*."""
+    if sys.platform == "win32":
+        import msvcrt
+
+        try:
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError:
+            return False
+    import fcntl
+
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except OSError:
+        return False
+
+
+def _release_os_lock(fd: int) -> None:
+    try:
+        if sys.platform == "win32":
+            import msvcrt
+
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    except OSError:
+        logger.debug("Could not release the sign-in lock cleanly", exc_info=True)
+    finally:
+        os.close(fd)
+
+
+class _SessionLock:
+    """Exclusive lock on the sign-in files: across threads (one _PathLock per
+    lock path, shared by every AuthManager in the process) and across
+    processes (flock / msvcrt.locking on ``<auth_file>.lock``).
+
+    Not re-entrant: acquiring it again from the holding thread is a
+    programming error and raises RuntimeError at once. The lock file is
+    never unlinked — removing it would let a later opener lock a different
+    inode and defeat the exclusion.
+    """
+
+    def __init__(self, lock_path: Path) -> None:
+        self._path = lock_path
+        self._state = _path_lock(lock_path)
+        self._fd: int | None = None
+        self.last_error: OSError | None = None
+
+    def _check_not_held_by_me(self) -> None:
+        if self._state.owner == threading.get_ident():
+            raise RuntimeError("session lock is not re-entrant")
+
+    def acquire(self, timeout: float = _LOCK_TIMEOUT_SECONDS) -> None:
+        """Wait up to *timeout* seconds — one deadline covering both the
+        thread mutex and the OS lock — then raise SessionLockTimeoutError. An
+        OSError opening the lock file propagates."""
+        self._check_not_held_by_me()
+        deadline = time.monotonic() + timeout
+        if not self._state.mutex.acquire(timeout=max(timeout, 0.0)):
+            raise SessionLockTimeoutError(f"sign-in lock {self._path} is held by another thread")
+        try:
+            fd = _open_lock_file(self._path)
+            try:
+                while not _try_os_lock(fd):
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise SessionLockTimeoutError(
+                            f"sign-in lock {self._path} is held by another process"
+                        )
+                    time.sleep(min(_LOCK_POLL_SECONDS, remaining))
+            except BaseException:
+                os.close(fd)
+                raise
+        except BaseException:
+            self._state.mutex.release()
+            raise
+        self._fd = fd
+        self._state.owner = threading.get_ident()
+
+    def try_acquire(self) -> str:
+        """Non-blocking: ``"acquired"``; ``"held"`` by another thread or
+        process; or ``"unavailable"`` — the lock file could not be opened,
+        which says nothing about other holders (``last_error`` has why)."""
+        self._check_not_held_by_me()
+        if not self._state.mutex.acquire(blocking=False):
+            return "held"
+        try:
+            fd = _open_lock_file(self._path)
+        except OSError as exc:
+            self._state.mutex.release()
+            self.last_error = exc
+            return "unavailable"
+        if not _try_os_lock(fd):
+            os.close(fd)
+            self._state.mutex.release()
+            return "held"
+        self._fd = fd
+        self._state.owner = threading.get_ident()
+        return "acquired"
+
+    def release(self) -> None:
+        if self._fd is None:
+            return
+        fd, self._fd = self._fd, None
+        self._state.owner = None
+        try:
+            _release_os_lock(fd)
+        finally:
+            self._state.mutex.release()
+
+    def __enter__(self) -> _SessionLock:
+        self.acquire()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.release()
+
+
+_MISSING_STAT = (-1, -1, -1)
+
+
+def file_signature(path: str | os.PathLike[str] | None) -> tuple[int, int, int]:
+    """``(st_ino, st_mtime_ns, st_size)`` of *path*, or a sentinel when there
+    is no such file (or it cannot be stat'ed). The files this module writes
+    are only ever replaced atomically, so a changed triple means different
+    bytes; the inode guards against a same-nanosecond, same-size rewrite."""
+    if path is None:
+        return _MISSING_STAT
+    try:
+        st = os.stat(path)
+    except OSError:
+        return _MISSING_STAT
+    return (st.st_ino, st.st_mtime_ns, st.st_size)
+
+
+@dataclass(frozen=True)
+class _FileRead:
+    """One read of a sign-in file: its bytes, or why there are none.
+
+    ``data`` is None both for a missing file and for one that exists but
+    could not be read; ``error`` tells the two apart. Consumers must never
+    collapse "unreadable" into "absent": absence is a legacy shape that
+    inherits trust, an unreadable record forbids everything.
+    """
+
+    data: bytes | None
+    stat: tuple[int, int, int]
+    error: OSError | None = None
+
+    @property
+    def missing(self) -> bool:
+        return self.data is None and self.error is None
+
+    @property
+    def unreadable(self) -> bool:
+        return self.error is not None
+
+    @property
+    def key(self) -> tuple[bytes | None, bool]:
+        """What two reads of the same file are compared on."""
+        return self.data, self.unreadable
+
+
+def _read_with_stat(path: str | os.PathLike[str]) -> _FileRead:
+    """Read *path* and fstat the very descriptor the bytes came from."""
+    try:
+        with open(path, "rb") as f:
+            st = os.fstat(f.fileno())
+            return _FileRead(f.read(), (st.st_ino, st.st_mtime_ns, st.st_size))
+    except FileNotFoundError:
+        return _FileRead(None, _MISSING_STAT)
+    except OSError as exc:
+        return _FileRead(None, file_signature(path), exc)
 
 
 _ACCOUNT_SCHEMA_VERSION = 1
@@ -199,6 +467,242 @@ class _ProbedAccount:
 class _RecordedIdentity:
     slot: int
     channel_id: str
+
+
+@dataclass(frozen=True)
+class _SessionOwner:
+    """What a renewal attempt saw on disk when it started: the auth.json
+    hash and the record's revision. A commit guarded by an owner refuses
+    when either differs — a newer ``ytm setup``, even one that wrote
+    byte-identical headers, is never overwritten."""
+
+    auth_sha256: str
+    revision: str | None
+
+
+def _identity_from_record(record: dict[str, Any] | None) -> _RecordedIdentity | None:
+    if record is None or record.get("verified") is False:
+        return None
+    channel_id = record.get("channel_id")
+    slot = record.get("x-goog-authuser")
+    if not (isinstance(channel_id, str) and _CHANNEL_ID_RE.fullmatch(channel_id)):
+        return None
+    if not (isinstance(slot, str) and slot.isdigit()):
+        return None
+    return _RecordedIdentity(slot=int(slot), channel_id=channel_id)
+
+
+@dataclass(frozen=True)
+class _SessionPair:
+    """One consistent snapshot of auth.json and the record describing those
+    exact bytes (``record`` is None when there is no usable one)."""
+
+    auth_bytes: bytes
+    record: dict[str, Any] | None
+
+    @property
+    def identity(self) -> _RecordedIdentity | None:
+        return _identity_from_record(self.record)
+
+    @property
+    def owner(self) -> _SessionOwner:
+        revision = self.record.get("revision") if self.record is not None else None
+        return _SessionOwner(
+            _sha256(self.auth_bytes), revision if isinstance(revision, str) else None
+        )
+
+
+def _owner_of(auth_bytes: bytes | None, record_raw: bytes | None) -> _SessionOwner | None:
+    """The owner the files on disk currently describe (None without auth.json)."""
+    if auth_bytes is None:
+        return None
+    record = _parse_record(record_raw)
+    auth_sha256 = _sha256(auth_bytes)
+    revision = (
+        record.get("revision") if record and record.get("auth_sha256") == auth_sha256 else None
+    )
+    return _SessionOwner(auth_sha256, revision if isinstance(revision, str) else None)
+
+
+def _parse_record(raw: bytes | None) -> dict[str, Any] | None:
+    """account.json as a dict, or None when missing, malformed or another schema."""
+    if raw is None:
+        return None
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict) or data.get("schema_version") != _ACCOUNT_SCHEMA_VERSION:
+        return None
+    return data
+
+
+def _sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _serialize_headers(headers: dict) -> bytes:
+    """The one serialisation of an auth.json candidate: probed and committed as is."""
+    return json.dumps(headers, ensure_ascii=True, indent=4, sort_keys=True).encode("utf-8")
+
+
+def _candidate_payload(base_headers: dict, slot: int) -> bytes:
+    return _serialize_headers({**base_headers, "x-goog-authuser": str(slot)})
+
+
+def _build_record(
+    account: _ProbedAccount, auth_payload: bytes, stream_sha256: str | None, *, verified: bool
+) -> dict[str, Any]:
+    """The account.json record for exactly *auth_payload* and the jar hashed
+    as *stream_sha256* (None: this session has no stream jar)."""
+    return {
+        "schema_version": _ACCOUNT_SCHEMA_VERSION,
+        "x-goog-authuser": str(account.slot),
+        "channel_id": account.channel_id,
+        "name": account.name,
+        "handle": account.handle or None,
+        "verified": verified,
+        "auth_sha256": _sha256(auth_payload),
+        "stream_sha256": stream_sha256,
+        "revision": os.urandom(16).hex(),
+    }
+
+
+def _record_writer(record: dict[str, Any]) -> Callable[[IO[Any]], None]:
+    def _write(f: IO[Any]) -> None:
+        json.dump(record, f, ensure_ascii=True, indent=4, sort_keys=True)
+
+    return _write
+
+
+def _bytes_writer(data: bytes) -> Callable[[IO[Any]], None]:
+    def _write(f: IO[Any]) -> None:
+        f.write(data)
+
+    return _write
+
+
+def _build_stream_cookiejar(jar: Iterable[Cookie]) -> bytes:
+    """Netscape-format bytes of the wide youtube.com/google.com cookiejar that
+    stream.py's yt-dlp resolver loads.
+
+    Builds a fresh jar rather than mutating *jar* in place — callers may
+    own or share that iterable, and this function has no reason to assume
+    it's safe to consume destructively.
+    """
+    from yt_dlp.cookies import YoutubeDLCookieJar
+
+    stream_jar = YoutubeDLCookieJar()
+    for cookie in jar:
+        bare = cookie.domain.lstrip(".")
+        if bare in ("youtube.com", "google.com") or bare.endswith((".youtube.com", ".google.com")):
+            value = cookie.value or ""
+            if _has_control_chars(cookie.name, value):
+                continue
+            stream_jar.set_cookie(cookie)
+    buffer = io.StringIO()
+    # save()'s stub types filename as str | None, but its open() accepts a
+    # file object directly at runtime (non-path-like branch truncates and
+    # reuses it) — verified against yt-dlp source.
+    stream_jar.save(buffer, ignore_discard=True, ignore_expires=True)  # type: ignore[arg-type]
+    return buffer.getvalue().encode("utf-8")
+
+
+# ── Stream cookiejar vouching (consumed by stream.py) ────────────────────
+
+
+@dataclass(frozen=True)
+class VouchedJar:
+    """Result of read_vouched_stream_jar: the jar bytes the resolver may load
+    (None → stream anonymously) and the signature of the exact file snapshot
+    that decision was made on."""
+
+    payload: bytes | None
+    signature: tuple[Any, ...]
+
+
+def _vouch_failure(auth: _FileRead, record: _FileRead, jar: _FileRead) -> str | None:
+    """Why the jar must not be used, or None when it may.
+
+    A jar is vouched for when the record describing the current auth.json
+    carries its hash. Two legacy shapes are accepted as today's trust:
+    an install with auth.json and NO record file at all, and a record that
+    parses but has no ``stream_sha256`` key — both predate this version,
+    and AuthManager._leave_legacy_locked makes sure this version never
+    creates either of them (a strict record is published before any jar).
+    A record that exists but cannot be read, or does not parse, is neither:
+    it refuses.
+    """
+    if jar.data is None:
+        return "the stream cookie file is unreadable"
+    if auth.unreadable:
+        return "auth.json is unreadable"
+    if auth.data is None:
+        return "auth.json is missing"
+    if record.unreadable:
+        return f"account.json cannot be read ({record.error})"
+    if record.data is None:
+        return None
+    parsed = _parse_record(record.data)
+    if parsed is None:
+        return "account.json is malformed"
+    record_dict = parsed
+    if record_dict.get("auth_sha256") != _sha256(auth.data):
+        return "account.json does not describe the current auth.json"
+    if "stream_sha256" not in record_dict:
+        return None
+    expected = record_dict["stream_sha256"]
+    if expected is None:
+        return "the saved sign-in has no stream cookie file"
+    if expected != _sha256(jar.data):
+        return "the stream cookie file does not match the saved sign-in"
+    return None
+
+
+def read_vouched_stream_jar(jar_path: str, session: tuple[str, str] | None) -> VouchedJar:
+    """Bytes of the stream cookie jar at *jar_path* that the sign-in files
+    vouch for, or None (stream anonymously). *session* is
+    ``(auth_path, account_path)``.
+
+    Every file is read as open → fstat → read, so the returned signature
+    ``(jar_path, jar, auth, record)`` of ``(st_ino, st_mtime_ns, st_size)``
+    triples describes the bytes that were actually checked (these files are
+    only ever replaced atomically). The record is read before and after the
+    others and must not have changed in between; three inconsistent
+    attempts refuse for this snapshot — the next signature change reruns
+    the check. Every refusal logs one warning naming the reason.
+    """
+    if session is None:
+        logger.warning(
+            "Stream cookie file %s is not used: no sign-in files to check it against", jar_path
+        )
+        return VouchedJar(None, (jar_path, file_signature(jar_path), _MISSING_STAT, _MISSING_STAT))
+    auth_path, record_path = session
+    signature: tuple[Any, ...] = (jar_path, _MISSING_STAT, _MISSING_STAT, _MISSING_STAT)
+    for _ in range(3):
+        record = _read_with_stat(record_path)
+        auth = _read_with_stat(auth_path)
+        jar = _read_with_stat(jar_path)
+        record_again = _read_with_stat(record_path)
+        signature = (jar_path, jar.stat, auth.stat, record.stat)
+        if record.key != record_again.key:
+            continue
+        reason = _vouch_failure(auth, record, jar)
+        if reason is None:
+            return VouchedJar(jar.data, signature)
+        logger.warning(
+            "Stream cookie file %s is not used: %s. Streaming without session cookies; "
+            "run `ytm setup` to refresh it.",
+            jar_path,
+            reason,
+        )
+        return VouchedJar(None, signature)
+    logger.warning(
+        "Stream cookie file %s is not used: the sign-in files changed while they were "
+        "being checked",
+        jar_path,
+    )
+    return VouchedJar(None, signature)
 
 
 def _channel_id_from_account_menu(response: Any) -> str | None:
@@ -289,12 +793,15 @@ class AuthManager:
         self._auth_file = auth_file
         self._cookies_file = normalize_cookiefile(cookies_file)
         self._stream_cookies_file = stream_cookies_file
-        # Identity of the session in auth.json (see _write_account_file).
+        # Identity of the session in auth.json (see _commit_session).
         # Lives next to auth.json (ACCOUNT_FILE for the default location) so
         # tests pointing auth_file at a temp dir never touch the real one.
         self._account_file = (
             account_file if account_file is not None else auth_file.with_name("account.json")
         )
+        # Cross-process/thread lock for every write to the files above; also
+        # next to auth.json, for the same reason. Never unlinked.
+        self._lock_path = auth_file.with_name(auth_file.name + ".lock")
 
     @property
     def auth_file(self) -> Path:
@@ -323,17 +830,22 @@ class AuthManager:
         The client is built from the snapshot's parsed headers, never from
         the path: a constructor re-reading the file could load a different
         session than the one the record was checked against (another
-        process's ``ytm setup`` landing and rolling back in between), and a
-        client tagged with the wrong identity would defeat the retry guard
-        in YTMusicService.
+        process's ``ytm setup`` landing in between), and a client tagged
+        with the wrong identity would defeat the retry guard in
+        YTMusicService.
+
+        Raises SessionBusyError while another writer is mid-replacement; that is
+        not an OSError and is never turned into an unbound client here.
         """
         try:
-            payload = self._auth_file.read_bytes()
+            pair = self._read_session_pair()
         except OSError:
+            # Missing or unreadable auth.json only: the client built from the
+            # path reports that itself, as before.
             return YTMusic(str(self._auth_file), user=user), None
-        recorded = self._load_recorded_identity(payload)
-        client = YTMusic(json.loads(payload), user=user)
-        return client, recorded.channel_id if recorded is not None else None
+        identity = pair.identity
+        client = YTMusic(json.loads(pair.auth_bytes), user=user)
+        return client, identity.channel_id if identity is not None else None
 
     def validate(self) -> bool:
         """Verify that the auth credentials actually work.
@@ -360,13 +872,37 @@ class AuthManager:
         """Attempt to silently refresh auth from cookies/browser.
 
         Called when the app detects an auth failure at runtime. Returns
-        True if fresh cookies were extracted and validation passed. Only the
+        True if fresh cookies were extracted, probed and committed. Only the
         account recorded by the last ``ytm setup`` is accepted; when the
         caller knows which account its failed client belonged to, pass it
         as *expected_channel_id* and the recorded account must be that one.
+
+        The pair on disk is read ONCE here; both sources (cookies file, then
+        browser) check the recorded identity from that snapshot and commit
+        only while the files still match it (see _commit_session).
         """
+        try:
+            pair = self._read_session_pair()
+        except SessionBusyError:
+            logger.warning(
+                "Automatic session renewal refused: another ytm process is updating the sign-in"
+            )
+            return False
+        except SessionUnreadableError as exc:
+            logger.warning("Automatic session renewal refused: %s", exc)
+            return False
+        except OSError:
+            logger.warning(
+                "Automatic session renewal refused: no saved session at %s", self._auth_file
+            )
+            return False
+        recorded, owner = pair.identity, pair.owner
+
         if self._cookies_file and self._refresh_from_cookies_file(
-            Path(self._cookies_file), expected_channel_id=expected_channel_id
+            Path(self._cookies_file),
+            expected_channel_id=expected_channel_id,
+            recorded=recorded,
+            owner=owner,
         ):
             return True
 
@@ -376,7 +912,11 @@ class AuthManager:
         browser, cookies, jar = detected
         try:
             return self._save_youtube_cookies(
-                cookies, stream_jar=jar, expected_channel_id=expected_channel_id
+                cookies,
+                stream_jar=jar,
+                expected_channel_id=expected_channel_id,
+                recorded=recorded,
+                owner=owner,
             )
         except Exception:
             logger.debug("Auto-refresh failed", exc_info=True)
@@ -439,7 +979,7 @@ class AuthManager:
         """Find a browser that has YouTube cookies.
 
         Returns ``(browser, youtube_cookies, full_jar)`` — the full jar feeds
-        the stream cookiejar (youtube.com + google.com) via _save_stream_cookiejar.
+        the stream cookiejar (youtube.com + google.com) via _commit_session.
         """
         _patch_yt_dlp_browsers()
 
@@ -454,73 +994,39 @@ class AuthManager:
                 continue
         return None
 
-    @staticmethod
-    def _backup_bytes(path: Path, label: str) -> bytes | None:
-        """Snapshot *path*'s contents so a failed refresh can restore them."""
-        if not path.exists():
-            return None
-        try:
-            return path.read_bytes()
-        except OSError:
-            logger.debug("Could not backup existing %s", label, exc_info=True)
-            return None
-
-    @staticmethod
-    def _restore_or_remove(path: Path, backup: bytes | None, label: str) -> None:
-        """Undo a failed refresh: restore *path* from *backup*, or remove it
-        if there was no prior backup (the refresh wrote it fresh).
-
-        Restores via _atomic_write(), the shared O_NOFOLLOW-temp-file-plus-
-        os.replace helper also used by _save_stream_cookiejar — a plain
-        write_bytes() would follow a symlink planted at *path* during the
-        network-bound window between backup and restore.
-        """
-        try:
-            if backup is not None:
-                payload = backup
-
-                def _write(f: IO[Any]) -> None:
-                    f.write(payload)
-
-                _atomic_write(path, "wb", _write)
-                logger.debug("Restored previous %s after cookies file validation failure", label)
-            elif path.exists():
-                path.unlink()
-        except OSError:
-            logger.warning("Failed to restore previous %s", label, exc_info=True)
-
     def _refresh_from_cookies_file(
         self,
         cookies_file: Path,
         interactive: bool = False,
         expected_channel_id: str | None = None,
+        *,
+        recorded: _RecordedIdentity | None = None,
+        owner: _SessionOwner | None = None,
     ) -> bool:
-        """Refresh auth from cookies file without losing working credentials."""
-        backup = self._backup_bytes(self._auth_file, "auth file")
-        account_backup = self._backup_bytes(self._account_file, "account file")
-        stream_backup = self._backup_bytes(self._stream_cookies_file, "stream cookiejar")
+        """Refresh auth from a cookies file.
 
-        if not self._extract_and_save_from_cookies_file(
-            cookies_file, interactive=interactive, expected_channel_id=expected_channel_id
-        ):
-            return False
-
-        try:
-            if self.validate():
-                return True
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
-            logger.warning("Network error during cookies-file validation; restoring backup")
-
-        self._restore_or_remove(self._auth_file, backup, "auth file")
-        self._restore_or_remove(self._account_file, account_backup, "account file")
-        self._restore_or_remove(self._stream_cookies_file, stream_backup, "stream cookiejar")
-        return False
+        The candidate session is probed before anything is written and the
+        commit is guarded by *owner*, so there is nothing to back up or roll
+        back: a refused or failed refresh leaves the working credentials as
+        they were, and a session another process committed meanwhile is
+        never restored over.
+        """
+        return self._extract_and_save_from_cookies_file(
+            cookies_file,
+            interactive=interactive,
+            expected_channel_id=expected_channel_id,
+            recorded=recorded,
+            owner=owner,
+        )
 
     def _extract_and_save_from_cookies_file(
         self,
         cookies_file: Path,
         interactive: bool = False,
         expected_channel_id: str | None = None,
+        *,
+        recorded: _RecordedIdentity | None = None,
+        owner: _SessionOwner | None = None,
     ) -> bool:
         """Extract YouTube cookies from a Netscape cookies.txt file and write auth.json."""
         if not cookies_file.exists():
@@ -559,6 +1065,8 @@ class AuthManager:
             interactive=interactive,
             stream_jar=jar,
             expected_channel_id=expected_channel_id,
+            recorded=recorded,
+            owner=owner,
         ):
             if interactive:
                 print(f"  Cookies extracted from file and saved: {cookies_file}")
@@ -593,6 +1101,9 @@ class AuthManager:
         interactive: bool = False,
         stream_jar: Iterable[Cookie] | None = None,
         expected_channel_id: str | None = None,
+        *,
+        recorded: _RecordedIdentity | None = None,
+        owner: _SessionOwner | None = None,
     ) -> bool:
         """Persist YouTube cookie headers into auth.json and record the account.
 
@@ -600,11 +1111,13 @@ class AuthManager:
         pick, and record the chosen account's identity in account.json.
 
         Silent (automatic renewal): only replace the session with the SAME
-        account. The channel ID recorded by the last setup must be found,
-        in the saved slot or — if the browser re-ordered its accounts — in
-        exactly one other slot. No recorded identity, no channel ID, no
-        match, or an ambiguous match refuses the renewal; the caller then
-        treats the session as expired and the user runs ``ytm setup`` once.
+        account. The channel ID recorded by the last setup (*recorded*, from
+        the snapshot the attempt started with) must be found, in the saved
+        slot or — if the browser re-ordered its accounts — in exactly one
+        other slot. No recorded identity, no channel ID, no match, or an
+        ambiguous match refuses the renewal; the caller then treats the
+        session as expired and the user runs ``ytm setup`` once. The commit
+        itself refuses when the files no longer match *owner*.
         """
         cookie_str = "; ".join(f"{c.name}={c.value}" for c in cookies)
 
@@ -626,28 +1139,24 @@ class AuthManager:
         if interactive:
             chosen = self._select_account_interactively(base_headers)
         else:
-            chosen = self._find_recorded_account(base_headers, expected_channel_id)
+            chosen = self._find_recorded_account(base_headers, expected_channel_id, recorded)
         if chosen is None:
             return False
 
-        headers = {**base_headers, "x-goog-authuser": str(chosen.slot)}
-        if not self._write_session(headers, chosen):
-            return False
-
-        if stream_jar is not None:
-            self._save_stream_cookiejar(stream_jar)
-        return True
+        # The same bytes that were probed for *chosen* are committed.
+        payload = _candidate_payload(base_headers, chosen.slot)
+        return self._commit_session(payload, chosen, stream_jar, owner=owner)
 
     # ── Account probing / selection ──────────────────────────────────
 
-    def _probe_slot(self, base_headers: dict, slot: int) -> _ProbedAccount | None:
-        """Ask YouTube Music who ``x-goog-authuser=slot`` is, or None."""
-        headers = {**base_headers, "x-goog-authuser": str(slot)}
+    def _probe_payload(self, payload: bytes, slot: int) -> _ProbedAccount | None:
+        """Ask YouTube Music who the session in *payload* (the exact auth.json
+        bytes a commit would write) is, or None."""
         tmp_path: str | None = None
         try:
             fd, tmp_path = tempfile.mkstemp(suffix=".json", dir=str(self._config_dir))
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(headers, f, ensure_ascii=True, indent=4, sort_keys=True)
+            with os.fdopen(fd, "wb") as f:
+                f.write(payload)
             return _probe_account(tmp_path, slot)
         except Exception:
             logger.debug("x-goog-authuser=%d did not work, skipping", slot)
@@ -664,7 +1173,8 @@ class AuthManager:
         valid_accounts = [
             account
             for slot in range(5)
-            if (account := self._probe_slot(base_headers, slot)) is not None
+            if (account := self._probe_payload(_candidate_payload(base_headers, slot), slot))
+            is not None
         ]
         if not valid_accounts:
             logger.warning(
@@ -710,16 +1220,21 @@ class AuthManager:
         return chosen
 
     def _find_recorded_account(
-        self, base_headers: dict, expected_channel_id: str | None = None
+        self,
+        base_headers: dict,
+        expected_channel_id: str | None = None,
+        recorded: _RecordedIdentity | None = None,
     ) -> _ProbedAccount | None:
         """Silent renewal: locate the account recorded by the last setup, or None.
 
-        With *expected_channel_id* (the account of the client whose call
+        *recorded* is the identity from the snapshot the renewal attempt
+        started from (never re-read here, so the check and the ownership
+        guard in _commit_session see the same pair). With
+        *expected_channel_id* (the account of the client whose call
         failed), the recorded account must be that one: a ``ytm setup`` for
         another account that landed in the meantime must not renew on its
         behalf.
         """
-        recorded = self._load_recorded_identity()
         if recorded is None:
             logger.warning(
                 "Automatic session renewal refused: no account identity is recorded for "
@@ -734,7 +1249,7 @@ class AuthManager:
             return None
 
         # The saved slot first; the rest only if the browser re-ordered its accounts.
-        probed = self._probe_slot(base_headers, recorded.slot)
+        probed = self._probe_payload(_candidate_payload(base_headers, recorded.slot), recorded.slot)
         if probed is not None and probed.channel_id == recorded.channel_id:
             return probed
 
@@ -742,7 +1257,8 @@ class AuthManager:
             account
             for slot in range(5)
             if slot != recorded.slot
-            and (account := self._probe_slot(base_headers, slot)) is not None
+            and (account := self._probe_payload(_candidate_payload(base_headers, slot), slot))
+            is not None
             and account.channel_id == recorded.channel_id
         ]
         if len(matches) == 1:
@@ -762,171 +1278,255 @@ class AuthManager:
 
     # ── Session + account record persistence ─────────────────────────
 
-    def _write_session(self, headers: dict, account: _ProbedAccount) -> bool:
-        """Write auth.json for *account*, then account.json describing it.
-
-        The previous account record is dropped first: if the auth write
-        fails part-way, stale metadata must never vouch for whatever is
-        left in auth.json. A failed account.json write only disables
-        automatic renewal (the session itself works), never the setup.
-        """
-        self._remove_account_file()
-        payload = json.dumps(headers, ensure_ascii=True, indent=4, sort_keys=True).encode("utf-8")
-        # O_NOFOLLOW (POSIX-only; getattr fallback for Windows) refuses to
-        # follow a symlink at the target path — defense-in-depth against
-        # a malicious local user planting a symlink in CONFIG_DIR.
+    def _read_record_raw(self) -> bytes | None:
+        """account.json bytes; None when there is no such file. A file that
+        exists but cannot be read raises — it is never reported as absent."""
         try:
-            fd = os.open(
-                str(self._auth_file),
-                os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0),
-                SECURE_FILE_MODE,
-            )
-            with os.fdopen(fd, "wb") as f:
-                f.write(payload)
-        except OSError:
-            logger.exception("Failed to write auth file %s", self._auth_file)
-            return False
+            return self._account_file.read_bytes()
+        except FileNotFoundError:
+            return None
 
-        self._write_account_file(account, payload)
-        return True
-
-    def _write_account_file(self, account: _ProbedAccount, auth_payload: bytes) -> bool:
-        """Record *account* as the identity of the auth.json whose bytes are *auth_payload*.
-
-        The record carries a hash of those bytes so metadata that no longer
-        matches auth.json (a partial write, an auth.json replaced by hand)
-        is ignored by _load_recorded_identity instead of authorising a
-        renewal.
-        """
-        record = {
-            "schema_version": _ACCOUNT_SCHEMA_VERSION,
-            "x-goog-authuser": str(account.slot),
-            "channel_id": account.channel_id,
-            "name": account.name,
-            "handle": account.handle or None,
-            "auth_sha256": hashlib.sha256(auth_payload).hexdigest(),
-        }
-
-        def _write(f: IO[Any]) -> None:
-            json.dump(record, f, ensure_ascii=True, indent=4, sort_keys=True)
-
+    def _read_record_or_refuse(self) -> bytes | None:
         try:
-            _atomic_write(self._account_file, "w", _write, encoding="utf-8")
-        except Exception:
-            logger.exception(
-                "Failed to write %s; automatic session renewal is disabled until the next "
-                "`ytm setup`",
-                self._account_file,
-            )
-            self._remove_account_file()
-            return False
-        if account.channel_id is None:
+            return self._read_record_raw()
+        except OSError as exc:
+            raise SessionUnreadableError(
+                f"{self._account_file} exists but cannot be read: {exc}"
+            ) from exc
+
+    def _read_pair_locked(self) -> tuple[bytes | None, bytes | None]:
+        """Raw auth.json and account.json bytes. The caller holds the session
+        lock, so the two reads are one consistent snapshot. An unreadable
+        record raises, which fails the commit."""
+        try:
+            auth_bytes: bytes | None = self._auth_file.read_bytes()
+        except FileNotFoundError:
+            auth_bytes = None
+        return auth_bytes, self._read_record_raw()
+
+    def _classify_pair(
+        self, auth_bytes: bytes, record_raw: bytes | None, *, writer_possible: bool
+    ) -> _SessionPair | None:
+        """Pair a snapshot of auth.json with the record that describes it.
+
+        A record for other auth bytes is either a commit in flight (auth.json
+        replaced, account.json not yet — *writer_possible*, so the caller
+        retries) or a permanent leftover of a crash between those two writes
+        (no writer holds the lock): then the session is usable but unbound,
+        exactly what a record-less session is today, and the record is
+        ignored with a warning. Nothing here ever invents an identity.
+        """
+        if record_raw is None:
+            return _SessionPair(auth_bytes, None)
+        record = _parse_record(record_raw)
+        if record is None:
+            # Never a mid-commit shape (records are replaced whole): permanent.
+            logger.warning("%s is malformed; ignoring it", self._account_file.name)
+            return _SessionPair(auth_bytes, None)
+        if record.get("auth_sha256") == _sha256(auth_bytes):
+            return _SessionPair(auth_bytes, record)
+        if writer_possible:
+            return None
+        logger.warning(
+            "%s does not describe the current %s; ignoring it",
+            self._account_file.name,
+            self._auth_file.name,
+        )
+        return _SessionPair(auth_bytes, None)
+
+    def _read_session_pair(self) -> _SessionPair:
+        """One consistent snapshot of auth.json + its record, without waiting.
+
+        Takes the session lock only when it is free right now (non-blocking
+        try). Acquired: the two files are read under it. Held by another
+        thread or process, or the lock file cannot be opened at all (which
+        proves nothing about other holders): a lock-free record → auth →
+        record read is used, consistent when both record reads agree and the
+        record describes the auth bytes. Three inconsistent attempts raise
+        SessionBusyError — a RuntimeError, never an OSError — so no fallback can
+        quietly build a client from a half-replaced pair. A record that exists
+        but cannot be read raises SessionUnreadableError the same way.
+
+        Raises OSError only for a missing/unreadable auth.json.
+        """
+        lock = _SessionLock(self._lock_path)
+        state = lock.try_acquire()
+        if state == "acquired":
+            try:
+                auth_bytes = self._auth_file.read_bytes()
+                record_raw = self._read_record_or_refuse()
+            finally:
+                lock.release()
+            pair = self._classify_pair(auth_bytes, record_raw, writer_possible=False)
+            assert pair is not None  # writer_possible=False always classifies
+            return pair
+        for _ in range(3):
+            first = self._read_record_or_refuse()
+            auth_bytes = self._auth_file.read_bytes()
+            second = self._read_record_or_refuse()
+            if first != second:
+                continue
+            pair = self._classify_pair(auth_bytes, first, writer_possible=True)
+            if pair is not None:
+                return pair
+        if state == "unavailable":
             logger.warning(
-                "No channel ID for this account; automatic session renewal is disabled until "
-                "the next `ytm setup`"
+                "Sign-in files are inconsistent and the lock %s cannot be opened (%s)",
+                self._lock_path,
+                lock.last_error,
             )
-        return True
-
-    def _remove_account_file(self) -> None:
-        try:
-            self._account_file.unlink(missing_ok=True)
-        except OSError:
-            logger.warning("Could not remove %s", self._account_file, exc_info=True)
+        raise SessionBusyError(f"{self._auth_file.name} is being replaced by another writer")
 
     def _load_recorded_identity(self, auth_bytes: bytes | None = None) -> _RecordedIdentity | None:
         """The identity account.json records for the CURRENT auth.json, or None.
 
         None (renewal refused) when the record is missing, malformed, has
-        no channel ID, or was written for different auth.json bytes.
-        *auth_bytes* lets a caller that already read auth.json check the
-        record against exactly that snapshot.
+        no channel ID, is unverified, or was written for different
+        auth.json bytes. *auth_bytes* lets a caller that already read
+        auth.json check the record against exactly that snapshot.
         """
         try:
-            data = json.loads(self._account_file.read_text(encoding="utf-8"))
-            current = auth_bytes if auth_bytes is not None else self._auth_file.read_bytes()
-        except (OSError, json.JSONDecodeError):
+            pair = self._read_session_pair()
+        except (OSError, SessionError):
             logger.debug("No usable account record at %s", self._account_file, exc_info=True)
             return None
-        if not isinstance(data, dict) or data.get("schema_version") != _ACCOUNT_SCHEMA_VERSION:
+        if auth_bytes is not None and auth_bytes != pair.auth_bytes:
             return None
-        channel_id = data.get("channel_id")
-        slot = data.get("x-goog-authuser")
-        if not (isinstance(channel_id, str) and _CHANNEL_ID_RE.fullmatch(channel_id)):
-            return None
-        if not (isinstance(slot, str) and slot.isdigit()):
-            return None
-        if data.get("auth_sha256") != hashlib.sha256(current).hexdigest():
-            logger.warning(
-                "%s does not describe the current %s; ignoring it",
-                self._account_file.name,
-                self._auth_file.name,
-            )
-            return None
-        return _RecordedIdentity(slot=int(slot), channel_id=channel_id)
+        return pair.identity
 
-    def _record_manual_identity(self) -> None:
-        """After a manual header paste, probe the pasted session for its identity."""
-        try:
-            saved = json.loads(self._auth_file.read_text(encoding="utf-8"))
-            slot = int(saved.get("x-goog-authuser", 0))
-            probed = _probe_account(str(self._auth_file), slot)
-        except Exception:
-            logger.debug("Could not probe the pasted session's account", exc_info=True)
-            probed = None
-        recorded = (
-            probed is not None
-            and self._write_account_file(probed, self._auth_file.read_bytes())
-            and probed.channel_id is not None
-        )
-        if not recorded:
-            print(_NO_RENEWAL_NOTE)
+    def _commit_session(
+        self,
+        payload: bytes,
+        account: _ProbedAccount,
+        jar: Iterable[Cookie] | None,
+        *,
+        owner: _SessionOwner | None = None,
+        verified: bool = True,
+    ) -> bool:
+        """Publish a new session: stream jar, auth.json, then account.json.
 
-    def _save_stream_cookiejar(self, jar: Iterable[Cookie]) -> bool:
-        """Write a wide youtube.com/google.com cookiejar for stream.py's yt-dlp resolver.
+        Runs under the session lock. Steps, each one atomic replace:
 
-        Builds a fresh jar rather than mutating *jar* in place — callers may
-        own or share that iterable, and this method has no reason to assume
-        it's safe to consume destructively.
+        0. With *owner* (an automatic renewal), refuse unless the pair on
+           disk is still the one the attempt started from — a newer
+           ``ytm setup`` is never overwritten. Setup passes no owner.
+        0b. A legacy pair (no record, or a record without ``stream_sha256``)
+           first gets a strict record for the *current* files, so the jar
+           published next can never be accepted under the legacy rule.
+        1. The stream jar for *jar* (removed when *jar* is None).
+        2. auth.json = *payload* — the exact bytes that were probed.
+        3. account.json for exactly those bytes, with a fresh revision and
+           the hash of the jar from step 1.
 
-        On failure any existing jar is removed: auth.json now belongs to
-        this session, and streaming must not keep using the previous one.
+        A failure or crash leaves every earlier step in place and every file
+        whole: after step 1 the record still describes the old auth.json (the
+        new jar is unvouched and refused by the resolver); after step 2 the
+        record describes nothing (the session works unbound, renewal is
+        refused until ``ytm setup``). No rollback, no repair, no cleanup.
         """
+        lock = _SessionLock(self._lock_path)
         try:
-            from yt_dlp.cookies import YoutubeDLCookieJar
-
-            stream_jar = YoutubeDLCookieJar()
-            for cookie in jar:
-                bare = cookie.domain.lstrip(".")
-                if bare in ("youtube.com", "google.com") or bare.endswith(
-                    (".youtube.com", ".google.com")
-                ):
-                    value = cookie.value or ""
-                    if _has_control_chars(cookie.name, value):
-                        continue
-                    stream_jar.set_cookie(cookie)
-
             self._config_dir.mkdir(parents=True, exist_ok=True)
-
-            def _write(f: IO[Any]) -> None:
-                # save()'s stub types filename as str | None, but its open()
-                # accepts a file object directly at runtime (non-path-like
-                # branch truncates and reuses it) — verified against yt-dlp
-                # source.
-                stream_jar.save(f, ignore_discard=True, ignore_expires=True)  # type: ignore[arg-type]
-
-            _atomic_write(self._stream_cookies_file, "w", _write, encoding="utf-8")
-        except Exception:
-            logger.exception("Failed to write stream cookiejar to %s", self._stream_cookies_file)
-            try:
-                self._stream_cookies_file.unlink(missing_ok=True)
-            except OSError:
-                logger.warning(
-                    "Could not remove stale stream cookiejar %s",
-                    self._stream_cookies_file,
-                    exc_info=True,
-                )
+            lock.acquire(timeout=_LOCK_TIMEOUT_SECONDS)
+        except SessionLockTimeoutError as exc:
+            logger.warning("Another ytm process is updating the sign-in; not saving (%s)", exc)
             return False
+        except OSError as exc:
+            logger.warning("Cannot lock the sign-in files: %s: %s", self._lock_path, exc)
+            return False
+        step = "reading the current sign-in"
+        try:
+            auth_bytes, record_raw = self._read_pair_locked()
+            if owner is not None and _owner_of(auth_bytes, record_raw) != owner:
+                logger.warning(
+                    "Automatic session renewal refused: the saved session changed while it "
+                    "was being renewed"
+                )
+                return False
+            step = "recording the current stream cookie file"
+            self._leave_legacy_locked(auth_bytes, record_raw)
+            step = "writing the stream cookie file"
+            stream_sha256: str | None = None
+            if jar is not None:
+                jar_bytes = _build_stream_cookiejar(jar)
+                _atomic_write(self._stream_cookies_file, "wb", _bytes_writer(jar_bytes))
+                stream_sha256 = _sha256(jar_bytes)
+            else:
+                self._stream_cookies_file.unlink(missing_ok=True)
+            step = f"writing {self._auth_file.name}"
+            _atomic_write(self._auth_file, "wb", _bytes_writer(payload))
+            step = f"writing {self._account_file.name}"
+            record = _build_record(account, payload, stream_sha256, verified=verified)
+            _atomic_write(self._account_file, "w", _record_writer(record), encoding="utf-8")
+        except Exception:
+            logger.exception("Failed to save the sign-in while %s", step)
+            return False
+        finally:
+            lock.release()
+        if account.channel_id is None or not verified:
+            logger.warning(
+                "No verified account identity for this session; automatic session renewal "
+                "is disabled until the next `ytm setup`"
+            )
         return True
+
+    def _leave_legacy_locked(self, auth_bytes: bytes | None, record_raw: bytes | None) -> None:
+        """Step 0b of _commit_session: make a legacy pair strict before any
+        new file is published.
+
+        Genuine legacy = no record file at all, or a record that parses (this
+        schema) but has no ``stream_sha256`` key — the two shapes that predate
+        this version. Only those inherit today's implicit trust: the record
+        written here keeps every field an existing record has and adds the
+        key with the hash of the jar on disk *now* (or null). With no record
+        it carries no identity (``channel_id`` null, ``verified`` false) —
+        renewal stays refused exactly as for a record-less session today.
+
+        A record that exists but does not parse, or is of another schema, is
+        NOT legacy: it is replaced by a provisional record that vouches for
+        no jar at all (``stream_sha256`` null) and no identity. Likewise on a
+        fresh install (no auth.json) the provisional record has
+        ``auth_sha256`` null too, so it vouches for nothing that is not yet
+        there.
+        """
+        parsed = _parse_record(record_raw)
+        if parsed is not None and "stream_sha256" in parsed:
+            return
+        invalid = record_raw is not None and parsed is None
+        if parsed is None:
+            slot = "0"
+            if auth_bytes is not None:
+                try:
+                    slot = str(int(json.loads(auth_bytes).get("x-goog-authuser", 0)))
+                except (ValueError, TypeError, AttributeError, json.JSONDecodeError):
+                    pass
+            record = {
+                "schema_version": _ACCOUNT_SCHEMA_VERSION,
+                "x-goog-authuser": slot,
+                "channel_id": None,
+                "name": "",
+                "handle": None,
+                "verified": False,
+                "auth_sha256": _sha256(auth_bytes) if auth_bytes is not None else None,
+            }
+        else:
+            record = dict(parsed)
+        jar_sha256: str | None = None
+        if auth_bytes is not None and not invalid:
+            try:
+                jar_sha256 = _sha256(self._stream_cookies_file.read_bytes())
+            except FileNotFoundError:
+                jar_sha256 = None
+        record["stream_sha256"] = jar_sha256
+        _atomic_write(self._account_file, "w", _record_writer(record), encoding="utf-8")
+        if invalid:
+            logger.warning(
+                "%s was malformed; replaced it with a record that vouches for no stream "
+                "cookie file and no account identity",
+                self._account_file.name,
+            )
+        else:
+            logger.info("Recorded the current stream cookie file for the saved sign-in")
 
     # ── Manual header paste (fallback) ───────────────────────────────
 
@@ -976,24 +1576,40 @@ class AuthManager:
             print()
 
         self._config_dir.mkdir(parents=True, exist_ok=True)
-        # The pasted headers are a new session: the previous account record
-        # must not survive to describe it.
-        self._remove_account_file()
         try:
             import ytmusicapi
 
-            ytmusicapi.setup(filepath=str(self._auth_file), headers_raw=normalized)
-            secure_chmod(self._auth_file, SECURE_FILE_MODE)
-            self._record_manual_identity()
-            if cookie_value is not None:
-                self._save_stream_cookiejar(_cookies_from_raw_header(cookie_value))
-            print()
-            print("  Browser authentication saved.")
-            return True
+            headers = json.loads(ytmusicapi.setup(headers_raw=normalized))
+            slot = int(headers.get("x-goog-authuser", 0))
         except Exception as exc:
+            # A rejected paste changes nothing on disk: the previous session
+            # and the record describing it stay exactly as they were.
             logger.error("Failed to parse headers: %s", exc)
             print(f"\n  Error: {exc}")
             return False
+
+        # The bytes probed below are the bytes committed: the slot is
+        # normalised before the single serialisation.
+        headers["x-goog-authuser"] = str(slot)
+        payload = _serialize_headers(headers)
+        cookie_value = headers.get("cookie")
+        jar = _cookies_from_raw_header(cookie_value) if cookie_value else None
+
+        probed = self._probe_payload(payload, slot)
+        verified = probed is not None
+        if probed is None:
+            logger.warning(
+                "Could not verify the pasted session; saving it without an account identity"
+            )
+            probed = _ProbedAccount(slot=slot, name="", handle="", channel_id=None)
+        if not self._commit_session(payload, probed, jar, verified=verified):
+            print("\n  Error: could not save the sign-in. See the log for details.")
+            return False
+        print()
+        print("  Browser authentication saved.")
+        if probed.channel_id is None:
+            print(_NO_RENEWAL_NOTE)
+        return True
 
 
 # ── Header normalization (for manual paste) ──────────────────────────
@@ -1046,7 +1662,7 @@ def _has_control_chars(*values: str) -> bool:
 
     Both cookiejar formats this module writes (Netscape, and the raw-header
     fallback) are line-oriented — an embedded control character in a cookie
-    name/value would corrupt the file. Shared by _save_stream_cookiejar and
+    name/value would corrupt the file. Shared by _build_stream_cookiejar and
     _cookies_from_raw_header, the two places that build Cookie objects from
     untrusted input (browser-extracted and user-pasted, respectively).
     """

--- a/src/ytm_player/services/stream.py
+++ b/src/ytm_player/services/stream.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import logging
-import os
 import re
 import threading
 import time
@@ -53,17 +53,30 @@ def _detect_stream_cookies() -> str | None:
     return str(STREAM_COOKIES_FILE) if STREAM_COOKIES_FILE.exists() else None
 
 
-def _session_cookiejar_signature() -> tuple[str, int, int] | None:
-    """``(path, mtime_ns, size)`` of the stream cookiejar the resolver should be
-    using right now, or None.
+def _detect_session_record() -> tuple[str, str] | None:
+    """``(auth.json path, account.json path)`` the stream cookiejar is checked
+    against — AuthManager's record vouches for the jar by hash (see
+    auth.read_vouched_stream_jar). No existence check: a missing file is
+    part of what the check decides on. Tests point this at a scratch pair.
+    """
+    from ytm_player.config.paths import ACCOUNT_FILE, AUTH_FILE
+
+    return str(AUTH_FILE), str(ACCOUNT_FILE)
+
+
+def _session_cookiejar_signature() -> tuple[Any, ...] | None:
+    """Signature of the stream cookiejar the resolver should be using right
+    now — ``(jar path, jar, auth.json, account.json)`` with each file as an
+    ``(st_ino, st_mtime_ns, st_size)`` triple — or None.
 
     None unless ``[yt_dlp] use_session_cookies`` is on (streaming is anonymous
     by default) and no explicit ``[yt_dlp] cookies_file`` is configured (that
     file is the user's own and goes through yt-dlp's ``cookiefile``), or when
-    the jar file doesn't exist. Compared on every _get_ydl() call so a jar
-    rewritten by ``ytm setup`` or a mid-session auto-refresh is picked up by
-    the next resolve instead of the cached YoutubeDL instance keeping its
-    stale in-memory copy.
+    the jar file doesn't exist. Compared on every _get_ydl() call so a change
+    to ANY of the three files — a jar rewritten by ``ytm setup`` or a
+    mid-session auto-refresh, but also an auth.json or account.json replaced
+    on its own — rebuilds the instance and reruns the vouching check instead
+    of the cached YoutubeDL instance keeping cookies it may no longer use.
     """
     settings = get_settings().yt_dlp
     if not settings.use_session_cookies or normalize_cookiefile(settings.cookies_file):
@@ -71,11 +84,11 @@ def _session_cookiejar_signature() -> tuple[str, int, int] | None:
     path = _detect_stream_cookies()
     if path is None:
         return None
-    try:
-        st = os.stat(path)
-    except OSError:
-        return None
-    return (path, st.st_mtime_ns, st.st_size)
+    from ytm_player.services.auth import file_signature
+
+    session = _detect_session_record()
+    auth_path, record_path = session if session is not None else (None, None)
+    return (path, file_signature(path), file_signature(auth_path), file_signature(record_path))
 
 
 class _YtDlpLogger:
@@ -163,7 +176,7 @@ class StreamResolver:
         self._ydl_generation = 0
         # Signature of the stream cookiejar file self._ydl was built against
         # (see _session_cookiejar_signature); None when none was loaded.
-        self._ydl_cookiejar_sig: tuple[str, int, int] | None = None
+        self._ydl_cookiejar_sig: tuple[Any, ...] | None = None
         # YoutubeDL is not thread-safe; a play resolve and a prefetch can run
         # on separate threads against the shared instance, so extract_info()
         # calls are serialized. Only the network call is held under it.
@@ -205,7 +218,7 @@ class StreamResolver:
         }
         return apply_configured_yt_dlp_options(opts, settings)
 
-    def _build_ydl(self, opts: dict) -> tuple[Any, tuple[str, int, int] | None]:
+    def _build_ydl(self, opts: dict) -> tuple[Any, tuple[Any, ...] | None]:
         """Construct a YoutubeDL instance from *opts* and, when
         ``[yt_dlp] use_session_cookies`` is on, load the stream cookiejar into it.
 
@@ -218,7 +231,12 @@ class StreamResolver:
         through ``cookiefile`` — that file is theirs, and write-back is
         yt-dlp's normal behaviour for it.
 
-        Returns the instance and the jar signature it was built against.
+        Only a jar the sign-in record vouches for is loaded (see
+        auth.read_vouched_stream_jar); the bytes loaded are the bytes that
+        were checked, and the signature cached with the instance is the one
+        of that exact snapshot — never a separate stat taken before or after.
+
+        Returns the instance and the signature it was built against.
         """
         import yt_dlp  # Lazy import
 
@@ -227,10 +245,23 @@ class StreamResolver:
         ydl = yt_dlp.YoutubeDL(opts)  # type: ignore[arg-type]
         sig = _session_cookiejar_signature()
         if sig is not None:
-            try:
-                ydl.cookiejar.load(sig[0], ignore_discard=True, ignore_expires=True)
-            except Exception:
-                logger.warning("Could not load stream cookiejar %s", sig[0], exc_info=True)
+            from ytm_player.services.auth import read_vouched_stream_jar
+
+            vouched = read_vouched_stream_jar(sig[0], _detect_session_record())
+            sig = vouched.signature
+            if vouched.payload is not None:
+                try:
+                    # load()'s stub types filename as str | None, but its
+                    # open() accepts a file object directly at runtime
+                    # (non-path-like branch yields it as is) — verified
+                    # against yt-dlp source.
+                    ydl.cookiejar.load(
+                        io.StringIO(vouched.payload.decode("utf-8")),  # type: ignore[arg-type]
+                        ignore_discard=True,
+                        ignore_expires=True,
+                    )
+                except Exception:
+                    logger.warning("Could not load stream cookiejar %s", sig[0], exc_info=True)
         return ydl, sig
 
     def _get_ydl(self) -> Any:

--- a/tests/test_cli/test_setup_command.py
+++ b/tests/test_cli/test_setup_command.py
@@ -1,0 +1,41 @@
+"""`ytm setup` tells the user when a ytm instance is running."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from click.testing import CliRunner
+
+from ytm_player.cli import main
+from ytm_player.config.settings import Settings
+
+
+def _fake_manager(monkeypatch) -> MagicMock:
+    manager = MagicMock()
+    manager.is_authenticated.return_value = False
+    manager.setup_interactive.return_value = True
+    manager.validate.return_value = True
+    monkeypatch.setattr("ytm_player.cli.AuthManager", lambda **kwargs: manager)
+    monkeypatch.setattr("ytm_player.cli.get_settings", lambda: Settings())
+    return manager
+
+
+def test_setup_says_to_restart_a_running_instance(monkeypatch):
+    manager = _fake_manager(monkeypatch)
+    monkeypatch.setattr("ytm_player.cli.get_running_pid", lambda: 4242)
+
+    result = CliRunner().invoke(main, ["setup"])
+
+    assert result.exit_code == 0, result.output
+    assert "ytm is running (PID 4242). Restart it after setup" in result.output
+    manager.setup_interactive.assert_called_once_with(manual=False, browser=None)
+
+
+def test_setup_is_quiet_when_no_instance_is_running(monkeypatch):
+    _fake_manager(monkeypatch)
+    monkeypatch.setattr("ytm_player.cli.get_running_pid", lambda: None)
+
+    result = CliRunner().invoke(main, ["setup"])
+
+    assert result.exit_code == 0, result.output
+    assert "ytm is running" not in result.output

--- a/tests/test_services/test_auth.py
+++ b/tests/test_services/test_auth.py
@@ -1,14 +1,18 @@
 """Tests for ytm_player.services.auth."""
 
+import hashlib
 import json
 from unittest.mock import MagicMock
 
-from ytm_player.services.auth import AuthManager, _normalize_raw_headers
+from ytm_player.services.auth import AuthManager, _normalize_raw_headers, _SessionOwner
 
 
 class TestAutoRefresh:
     def test_reuses_cookies_found_during_browser_detection(self, tmp_path, monkeypatch):
-        manager = AuthManager(config_dir=tmp_path, auth_file=tmp_path / "auth.json")
+        auth_file = tmp_path / "auth.json"
+        auth_bytes = b'{"cookie": "SAPISID=x", "x-goog-authuser": "0"}'
+        auth_file.write_bytes(auth_bytes)
+        manager = AuthManager(config_dir=tmp_path, auth_file=auth_file)
         cookies = [MagicMock()]
         jar = [MagicMock(), MagicMock()]
         detect = MagicMock(return_value=("brave", cookies, jar))
@@ -19,7 +23,25 @@ class TestAutoRefresh:
         assert manager.try_auto_refresh()
 
         detect.assert_called_once_with()
-        save.assert_called_once_with(cookies, stream_jar=jar, expected_channel_id=None)
+        # The snapshot taken at entry (no record → no identity) is what the
+        # browser source commits against.
+        save.assert_called_once_with(
+            cookies,
+            stream_jar=jar,
+            expected_channel_id=None,
+            recorded=None,
+            owner=_SessionOwner(hashlib.sha256(auth_bytes).hexdigest(), None),
+        )
+
+    def test_refresh_without_a_saved_session_is_refused_before_detection(
+        self, tmp_path, monkeypatch
+    ):
+        manager = AuthManager(config_dir=tmp_path, auth_file=tmp_path / "auth.json")
+        detect = MagicMock(return_value=("brave", [MagicMock()], [MagicMock()]))
+        monkeypatch.setattr(manager, "_detect_browser", detect)
+
+        assert manager.try_auto_refresh() is False
+        detect.assert_not_called()
 
     def test_silent_refresh_refuses_without_recorded_identity(self, tmp_path, monkeypatch, capsys):
         """No account.json (a session set up before identities were recorded):

--- a/tests/test_services/test_auth_cookies_file.py
+++ b/tests/test_services/test_auth_cookies_file.py
@@ -46,9 +46,9 @@ def test_extract_from_cookies_file_rejects_non_youtube_suffix(tmp_path):
     assert not auth_file.exists()
 
 
-def test_refresh_from_cookies_file_restores_previous_auth_on_validate_failure(
-    tmp_path, monkeypatch
-):
+def test_refresh_from_cookies_file_refused_probe_leaves_previous_auth(tmp_path, monkeypatch):
+    """The candidate session is probed before anything is written; a refusal
+    leaves the working credentials untouched (nothing to restore)."""
     cookies_file = tmp_path / "cookies.txt"
     _write_netscape_cookie_file(cookies_file)
 
@@ -57,10 +57,8 @@ def test_refresh_from_cookies_file_restores_previous_auth_on_validate_failure(
     auth_file.write_text(original)
 
     auth = AuthManager(auth_file=auth_file, stream_cookies_file=tmp_path / "stream_cookies.txt")
-
-    monkeypatch.setattr(auth, "validate", lambda: False)
     mock_ytm = MagicMock()
-    mock_ytm.get_account_info.return_value = {"accountName": "Alice"}
+    mock_ytm.get_account_info.return_value = {}  # no account in any slot
 
     with (
         _PATCH_SAPISID,
@@ -70,14 +68,17 @@ def test_refresh_from_cookies_file_restores_previous_auth_on_validate_failure(
     assert auth_file.read_text() == original
 
 
-def test_refresh_from_cookies_file_restores_backup_on_network_error(tmp_path, monkeypatch):
-    """If validate() raises a network error, backup should still be restored."""
+def test_refresh_from_cookies_file_commits_the_probed_session_without_validate(
+    tmp_path, monkeypatch
+):
+    """The probe already validated the exact bytes that are committed, so no
+    post-commit validate() runs — a network error there can no longer undo
+    (or roll back over) a committed session."""
     cookies_file = tmp_path / "cookies.txt"
     _write_netscape_cookie_file(cookies_file)
 
     auth_file = tmp_path / "headers_auth.json"
-    original = '{"cookie": "old=1"}'
-    auth_file.write_text(original)
+    auth_file.write_text('{"cookie": "old=1"}')
 
     auth = AuthManager(auth_file=auth_file, stream_cookies_file=tmp_path / "stream_cookies.txt")
 
@@ -92,5 +93,7 @@ def test_refresh_from_cookies_file_restores_backup_on_network_error(tmp_path, mo
         _PATCH_SAPISID,
         patch("ytm_player.services.auth.YTMusic", side_effect=_slot_zero_only(mock_ytm)),
     ):
-        assert auth._refresh_from_cookies_file(cookies_file, interactive=True) is False
-    assert auth_file.read_text() == original
+        assert auth._refresh_from_cookies_file(cookies_file, interactive=True) is True
+    saved = json.loads(auth_file.read_text(encoding="utf-8"))
+    assert saved["x-goog-authuser"] == "0"
+    assert "abc123" in saved["cookie"]

--- a/tests/test_services/test_auth_identity.py
+++ b/tests/test_services/test_auth_identity.py
@@ -259,6 +259,20 @@ def _switch_session_to(auth: AuthManager, slot: str, channel_id: str) -> None:
     _record(auth, slot, channel_id)
 
 
+def _make_record_strict(auth: AuthManager) -> None:
+    """Give the fixture record the keys every record written by this version
+    has, so a commit skips the legacy transition (step 0b)."""
+    record = json.loads(auth._account_file.read_text(encoding="utf-8"))
+    record["stream_sha256"] = None
+    auth._account_file.write_text(json.dumps(record), encoding="utf-8")
+
+
+def _real_atomic_write():
+    from ytm_player.services.auth import _atomic_write
+
+    return _atomic_write
+
+
 @pytest.fixture
 def browser(monkeypatch):
     monkeypatch.setattr(
@@ -529,48 +543,65 @@ class TestSetupRecordsIdentity:
         assert "automatic session renewal is not available" in capsys.readouterr().out
         assert auth.try_auto_refresh() is False
 
-    def test_account_file_write_failure_keeps_session_but_disables_renewal(
+    def test_account_file_write_failure_leaves_an_unbound_session(
         self, tmp_path, browser, monkeypatch, caplog
     ):
+        """The record is the last file written. When only that write fails the
+        new auth.json is already in place: the session works, but without a
+        record describing it renewal is refused until `ytm setup`."""
         auth = _auth(tmp_path, "0")
+        _make_record_strict(auth)
         monkeypatch.setattr("ytm_player.services.auth.YTMusic", _fake_ytmusic({0: ME}))
+        real_atomic_write = _real_atomic_write()
+
+        def _fail_record(path, *args, **kwargs):
+            if path == auth._account_file:
+                raise OSError("disk full")
+            return real_atomic_write(path, *args, **kwargs)
 
         with (
-            patch("ytm_player.services.auth._atomic_write", side_effect=OSError("disk full")),
-            caplog.at_level("ERROR", logger="ytm_player.services.auth"),
+            patch("ytm_player.services.auth._atomic_write", side_effect=_fail_record),
+            caplog.at_level("WARNING", logger="ytm_player.services.auth"),
         ):
-            assert auth._save_youtube_cookies([_cookie()], interactive=True) is True
+            assert auth._save_youtube_cookies([_cookie()], interactive=True) is False
         assert _saved_slot(auth) == "0"
-        assert not auth._account_file.exists()
-        assert "automatic session renewal is disabled" in caplog.text
+        assert "Failed to save the sign-in while writing account.json" in caplog.text
+        assert auth._account_file.exists()
+        assert auth._load_recorded_identity() is None  # stale record ignored
+        assert "does not describe the current auth.json" in caplog.text
         assert auth.try_auto_refresh() is False
 
-    def test_auth_write_failure_removes_old_record(self, tmp_path, browser, monkeypatch):
+    def test_auth_write_failure_keeps_the_old_session_and_record(
+        self, tmp_path, browser, monkeypatch
+    ):
+        """auth.json is replaced atomically: a failed write leaves the previous
+        bytes and the record that describes them exactly as they were."""
         auth = _auth(tmp_path, "2")
+        _make_record_strict(auth)  # else step 0b rewrites the record first
+        old_auth = auth.auth_file.read_bytes()
+        old_record = auth._account_file.read_bytes()
         monkeypatch.setattr("ytm_player.services.auth.YTMusic", _fake_ytmusic({2: ME}))
-        real_open = auth._auth_file.__class__  # noqa: F841 (documentation)
+        real_atomic_write = _real_atomic_write()
 
-        def _fail_auth_open(path, *args, **kwargs):
-            if str(path) == str(auth._auth_file):
+        def _fail_auth(path, *args, **kwargs):
+            if path == auth.auth_file:
                 raise OSError("read-only")
-            return real_os_open(path, *args, **kwargs)
+            return real_atomic_write(path, *args, **kwargs)
 
-        import os
-
-        real_os_open = os.open
-        with patch("ytm_player.services.auth.os.open", side_effect=_fail_auth_open):
+        with patch("ytm_player.services.auth._atomic_write", side_effect=_fail_auth):
             assert auth.try_auto_refresh() is False
-        assert not auth._account_file.exists()
+        assert auth.auth_file.read_bytes() == old_auth
+        assert auth._account_file.read_bytes() == old_record
+        recorded = auth._load_recorded_identity()
+        assert recorded is not None and recorded.channel_id == ME_ID
 
     def test_manual_setup_replaces_previous_record(self, tmp_path, browser, monkeypatch):
         auth = _auth(tmp_path, "0", record=OTHER_ID)
         responses = iter(["Host: music.youtube.com", "Cookie: SAPISID=abc123", ""])
         monkeypatch.setattr("builtins.input", lambda: next(responses))
 
-        def _fake_setup(filepath, headers_raw):
-            Path(filepath).write_text(
-                '{"cookie": "SAPISID=abc123", "x-goog-authuser": "0"}', encoding="utf-8"
-            )
+        def _fake_setup(headers_raw=None, filepath=None):
+            return '{"cookie": "SAPISID=abc123", "x-goog-authuser": "0"}'
 
         monkeypatch.setattr("ytm_player.services.auth.YTMusic", _fake_ytmusic({0: ME}))
         with patch("ytmusicapi.setup", side_effect=_fake_setup):
@@ -579,27 +610,35 @@ class TestSetupRecordsIdentity:
         recorded = auth._load_recorded_identity()
         assert recorded is not None and recorded.channel_id == ME_ID
 
-    def test_manual_setup_probe_failure_leaves_no_record(
+    def test_manual_setup_probe_failure_records_an_unverified_session(
         self, tmp_path, browser, monkeypatch, capsys
     ):
+        """A paste that parses but cannot be verified is saved with a record
+        that carries no identity (`channel_id` null, `verified` false), so
+        the jar association is recorded while renewal stays refused."""
         auth = _auth(tmp_path, "0", record=OTHER_ID)
         responses = iter(["Host: music.youtube.com", "Cookie: SAPISID=abc123", ""])
         monkeypatch.setattr("builtins.input", lambda: next(responses))
 
-        def _fake_setup(filepath, headers_raw):
-            Path(filepath).write_text('{"cookie": "SAPISID=abc123"}', encoding="utf-8")
+        def _fake_setup(headers_raw=None, filepath=None):
+            return '{"cookie": "SAPISID=abc123"}'
 
         monkeypatch.setattr("ytm_player.services.auth.YTMusic", _fake_ytmusic({}))
         with patch("ytmusicapi.setup", side_effect=_fake_setup):
             assert auth.setup_interactive(manual=True) is True
 
-        assert not auth._account_file.exists()
-        assert "automatic session renewal is not available" in capsys.readouterr().out
+        record = json.loads(auth._account_file.read_text(encoding="utf-8"))
+        assert (record["channel_id"], record["verified"]) == (None, False)
+        assert record["auth_sha256"] == hashlib.sha256(auth.auth_file.read_bytes()).hexdigest()
+        assert auth._load_recorded_identity() is None
+        assert capsys.readouterr().out.count("automatic session renewal is not available") == 1
         assert auth.try_auto_refresh() is False
 
-    def test_cookies_file_refresh_restores_record_on_validate_failure(
+    def test_cookies_file_refresh_refused_by_probe_leaves_files_untouched(
         self, tmp_path, browser, monkeypatch
     ):
+        """No backup/restore any more: the candidate is probed before anything
+        is written, so a refused refresh changes nothing."""
         auth = _auth(tmp_path, "0")
         old_auth = auth.auth_file.read_bytes()
         old_record = auth._account_file.read_bytes()
@@ -607,8 +646,7 @@ class TestSetupRecordsIdentity:
         cookies_file.write_text(
             "# Netscape HTTP Cookie File\n.youtube.com\tTRUE\t/\tTRUE\t2147483647\tSAPISID\tabc\n"
         )
-        monkeypatch.setattr("ytm_player.services.auth.YTMusic", _fake_ytmusic({0: ME}))
-        monkeypatch.setattr(auth, "validate", lambda: False)
+        monkeypatch.setattr("ytm_player.services.auth.YTMusic", _fake_ytmusic({}))
 
         assert auth._refresh_from_cookies_file(cookies_file, interactive=True) is False
         assert auth.auth_file.read_bytes() == old_auth

--- a/tests/test_services/test_auth_lock_process.py
+++ b/tests/test_services/test_auth_lock_process.py
@@ -1,0 +1,237 @@
+"""The sign-in lock across processes.
+
+A child process holds ``auth.json.lock`` while the parent commits or reads.
+Synchronisation is by pipe ("locked" / "released" lines from the child,
+"release" on its stdin) and by events — never by elapsed time.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import threading
+from http.cookiejar import Cookie
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import make_ytmusic_service
+from ytm_player.services import auth as auth_module
+from ytm_player.services.auth import AuthManager, SessionBusyError, _ProbedAccount
+
+A_ID = "UC" + "a" * 22
+B_ID = "UC" + "b" * 22
+A = _ProbedAccount(slot=0, name="Synthetic A", handle="", channel_id=A_ID)
+B = _ProbedAccount(slot=1, name="Synthetic B", handle="", channel_id=B_ID)
+HEADERS_A = {"cookie": "SAPISID=a", "x-goog-authuser": "0"}
+HEADERS_B = {"cookie": "SAPISID=b", "x-goog-authuser": "1"}
+
+_CHILD = r"""
+import sys
+from pathlib import Path
+
+from ytm_player.services.auth import _SessionLock
+
+lock = _SessionLock(Path(sys.argv[1]))
+lock.acquire(timeout=10)
+print("locked", flush=True)
+for line in sys.stdin:
+    if line.strip() == "release":
+        break
+lock.release()
+print("released", flush=True)
+"""
+
+
+@pytest.fixture(autouse=True)
+def _no_real_browser_or_network(monkeypatch):
+    """Nothing in this module may reach a browser profile or the network."""
+    monkeypatch.setattr(AuthManager, "_detect_browser", staticmethod(lambda: None))
+
+    def _no_network(*args, **kwargs):
+        raise RuntimeError("network isolation: YTMusic constructed in a test")
+
+    monkeypatch.setattr("ytm_player.services.auth.YTMusic", _no_network)
+
+
+def _payload(headers: dict) -> bytes:
+    return json.dumps(headers, ensure_ascii=True, indent=4, sort_keys=True).encode("utf-8")
+
+
+def _cookie(value: str) -> Cookie:
+    return Cookie(
+        0,
+        "SAPISID",
+        value,
+        None,
+        False,
+        ".youtube.com",
+        True,
+        True,
+        "/",
+        True,
+        True,
+        None,
+        False,
+        None,
+        None,
+        {},
+    )
+
+
+def _mgr(tmp_path: Path) -> AuthManager:
+    cfg = tmp_path / "config"
+    cfg.mkdir(exist_ok=True)
+    return AuthManager(
+        config_dir=cfg,
+        auth_file=cfg / "auth.json",
+        cookies_file=None,
+        stream_cookies_file=cfg / "stream_cookies.txt",
+        account_file=cfg / "account.json",
+    )
+
+
+def _commit(mgr: AuthManager, headers: dict, account: _ProbedAccount) -> bool:
+    return mgr._commit_session(_payload(headers), account, [_cookie(account.name[-1].lower())])
+
+
+@contextlib.contextmanager
+def _child_holding(lock_path: Path):
+    """Run a child process that holds *lock_path* until told to release."""
+    src_dir = Path(auth_module.__file__).parents[2]
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(src_dir) + os.pathsep + env.get("PYTHONPATH", "")
+    child = subprocess.Popen(
+        [sys.executable, "-c", _CHILD, str(lock_path)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    assert child.stdin is not None and child.stdout is not None
+    try:
+        line = child.stdout.readline().strip()
+        if line != "locked":
+            _, err = child.communicate(timeout=10)
+            pytest.fail(f"child did not take the lock: {line!r} {err}")
+        yield child
+    finally:
+        if child.poll() is None:
+            with contextlib.suppress(OSError):
+                child.stdin.write("release\n")
+                child.stdin.flush()
+            child.communicate(timeout=10)
+
+
+def _release(child: subprocess.Popen) -> None:
+    assert child.stdin is not None and child.stdout is not None
+    child.stdin.write("release\n")
+    child.stdin.flush()
+    assert child.stdout.readline().strip() == "released"
+
+
+def test_commit_waits_for_another_process_and_runs_after_its_release(tmp_path, monkeypatch):
+    mgr = _mgr(tmp_path)
+    assert _commit(mgr, HEADERS_A, A)
+    marker = tmp_path / "released.marker"
+    attempted = threading.Event()
+    real_try = auth_module._try_os_lock
+
+    def spy_try(fd):
+        ok = real_try(fd)
+        if not ok:
+            attempted.set()
+        return ok
+
+    monkeypatch.setattr(auth_module, "_try_os_lock", spy_try)
+    observed: list[bool] = []
+    real_read = mgr._read_pair_locked
+
+    def spy_read():
+        observed.append(marker.exists())  # True only if the lock was taken after the release
+        return real_read()
+
+    monkeypatch.setattr(mgr, "_read_pair_locked", spy_read)
+    result: list[bool] = []
+
+    with _child_holding(mgr._lock_path) as child:
+        worker = threading.Thread(target=lambda: result.append(_commit(mgr, HEADERS_B, B)))
+        worker.start()
+        assert attempted.wait(10)  # the parent's commit has tried the OS lock and failed
+        marker.write_text("x", encoding="utf-8")
+        _release(child)
+        worker.join(30)
+
+    assert result == [True]
+    assert observed == [True]
+    assert json.loads(mgr.auth_file.read_bytes()) == HEADERS_B
+    record = json.loads(mgr._account_file.read_text(encoding="utf-8"))
+    assert record["auth_sha256"] == hashlib.sha256(mgr.auth_file.read_bytes()).hexdigest()
+
+
+def test_commit_refuses_when_another_process_holds_the_lock_for_the_whole_wait(
+    tmp_path, monkeypatch, caplog
+):
+    mgr = _mgr(tmp_path)
+    assert _commit(mgr, HEADERS_A, A)
+    before = (mgr.auth_file.read_bytes(), mgr._account_file.read_bytes())
+    monkeypatch.setattr(auth_module, "_LOCK_TIMEOUT_SECONDS", 0.2)
+
+    with _child_holding(mgr._lock_path) as child:
+        with caplog.at_level("WARNING", logger="ytm_player.services.auth"):
+            assert _commit(mgr, HEADERS_B, B) is False
+        _release(child)
+
+    assert "Another ytm process is updating the sign-in" in caplog.text
+    assert (mgr.auth_file.read_bytes(), mgr._account_file.read_bytes()) == before
+
+
+async def test_reads_never_wait_and_fail_closed_under_contention(tmp_path, monkeypatch, caplog):
+    mgr = _mgr(tmp_path)
+    assert _commit(mgr, HEADERS_A, A)
+    identity_client = lambda h, **kw: h  # noqa: E731
+
+    with _child_holding(mgr._lock_path) as child:
+        # Consistent pair, lock held elsewhere: the read returns at once.
+        with patch("ytm_player.services.auth.YTMusic", side_effect=identity_client):
+            client, identity = mgr.create_bound_client()
+        assert (client, identity) == (HEADERS_A, A_ID)
+
+        # The pair becomes inconsistent while the child still holds the lock:
+        # a writer may be mid-commit, so fail closed — no client at all.
+        mgr.auth_file.write_bytes(_payload(HEADERS_B))
+        with patch("ytm_player.services.auth.YTMusic") as ctor:
+            with pytest.raises(SessionBusyError):
+                mgr.create_bound_client()
+        ctor.assert_not_called()
+
+        refresh = MagicMock(return_value=True)
+        monkeypatch.setattr(mgr, "try_auto_refresh", refresh)
+        service = make_ytmusic_service(_ytm=None, _auth_manager=mgr)
+        assert await service.get_home() is None
+        refresh.assert_not_called()
+
+        if sys.platform != "win32" and os.geteuid() != 0:
+            # An unopenable lock file proves nothing about other holders.
+            os.chmod(mgr._lock_path, 0)
+            try:
+                with caplog.at_level("WARNING", logger="ytm_player.services.auth"):
+                    with pytest.raises(SessionBusyError):
+                        mgr.create_bound_client()
+                assert str(mgr._lock_path) in caplog.text
+            finally:
+                os.chmod(mgr._lock_path, 0o600)
+        _release(child)
+
+    # Lock free, same pair: a crash leftover → usable, unbound, with a warning.
+    with caplog.at_level("WARNING", logger="ytm_player.services.auth"):
+        with patch("ytm_player.services.auth.YTMusic", side_effect=identity_client):
+            client, identity = mgr.create_bound_client()
+    assert (client, identity) == (HEADERS_B, None)
+    assert "does not describe the current auth.json" in caplog.text

--- a/tests/test_services/test_auth_stream_cookiejar.py
+++ b/tests/test_services/test_auth_stream_cookiejar.py
@@ -1,13 +1,14 @@
-"""Tests for AuthManager._save_stream_cookiejar() and its call sites.
+"""Tests for the stream cookiejar AuthManager._commit_session() writes
+(built by _build_stream_cookiejar()) and its call sites.
 
-Covers the new stream-cookiejar artifact written alongside auth.json:
-symlink defense (O_NOFOLLOW + atomic replace), domain scoping
-(youtube.com/google.com family, confusable-suffix rejection), secure file
-mode, independent-failure behavior (a cookiejar write failure must never
-affect auth.json's own success/failure signal), _cookies_from_raw_header
+Covers the stream-cookiejar artifact written alongside auth.json:
+symlink defense (O_EXCL temp file + atomic replace, symlink destination
+refused), domain scoping (youtube.com/google.com family, confusable-suffix
+rejection), secure file mode, failure ordering (a cookiejar write failure
+stops the commit before auth.json is touched), _cookies_from_raw_header
 parsing for the manual-paste path, _setup_manual's end-to-end wiring, the
 account-scoping gate (no valid account => no cookiejar write), and
-_refresh_from_cookies_file's backup/restore extension for the cookiejar.
+_refresh_from_cookies_file's probe-before-write behaviour.
 
 Every test constructs AuthManager with config_dir, auth_file, AND
 stream_cookies_file all explicitly pointed at tmp_path — stream_cookies_file
@@ -18,7 +19,6 @@ write to the developer's/CI's actual ~/.config/ytm-player/.
 from __future__ import annotations
 
 import json
-import logging
 import sys
 import time
 from http.cookiejar import Cookie, MozillaCookieJar
@@ -28,9 +28,22 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ytm_player.config.paths import SECURE_FILE_MODE
-from ytm_player.services.auth import AuthManager, _atomic_write, _cookies_from_raw_header
+from ytm_player.services.auth import (
+    AuthManager,
+    _atomic_write,
+    _cookies_from_raw_header,
+    _ProbedAccount,
+)
 
 _PATCH_SAPISID = patch("ytm_player.services.auth.sapisid_from_cookie", return_value="fake_sapisid")
+_ACCOUNT = _ProbedAccount(slot=0, name="Alice", handle="", channel_id=None)
+_PAYLOAD = b'{"cookie": "SAPISID=synthetic", "x-goog-authuser": "0"}'
+
+
+def _commit(auth: AuthManager, jar) -> bool:
+    """Commit a synthetic session together with *jar* (the only way a stream
+    cookiejar is written)."""
+    return auth._commit_session(_PAYLOAD, _ACCOUNT, jar)
 
 
 def _slot_zero_only(mock_ytm):
@@ -108,22 +121,26 @@ def _write_netscape_cookie_file(path: Path, domain: str = ".youtube.com") -> Non
 # ── Step 1: symlink defense ─────────────────────────────────────────────────
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="O_NOFOLLOW is a POSIX-only defense")
 def test_symlink_target_is_not_followed(tmp_path):
-    """A symlink planted at the target path must not be written through —
-    proves the write path (O_NOFOLLOW temp file + atomic os.replace) is
-    actually wired in, not just documented."""
+    """A symlink planted at the target path is neither written through nor
+    replaced: _atomic_write refuses it, and the commit stops there — before
+    auth.json — so the previous session is untouched too."""
     stream_cookies_file = tmp_path / "stream_cookies.txt"
     victim = tmp_path / "victim.txt"
     victim.write_text("do not touch")
-    stream_cookies_file.symlink_to(victim)
+    try:
+        stream_cookies_file.symlink_to(victim)
+    except OSError as exc:  # pragma: no cover - Windows without the privilege
+        pytest.skip(f"cannot create a symlink here: {exc}")
 
     auth = _make_auth(tmp_path, stream_cookies_file=stream_cookies_file)
 
-    result = auth._save_stream_cookiejar([_cookie(".youtube.com")])
+    result = _commit(auth, [_cookie(".youtube.com")])
 
-    assert result is True
+    assert result is False
     assert victim.read_text() == "do not touch"
+    assert stream_cookies_file.is_symlink()
+    assert not auth.auth_file.exists()
 
 
 # ── Step 2: domain scoping ───────────────────────────────────────────────────
@@ -138,7 +155,7 @@ def test_success_writes_secure_file_scoped_to_youtube_google(tmp_path):
         _cookie("unrelated-shop.example", name="shop_cookie"),
     ]
 
-    auth._save_stream_cookiejar(jar)
+    assert _commit(auth, jar) is True
 
     assert auth._stream_cookies_file.exists()
     names = _read_cookie_names(auth._stream_cookies_file)
@@ -154,25 +171,25 @@ def test_rejects_confusable_domain_suffix(tmp_path):
         _cookie("notyoutube.com", name="confusable_cookie"),
     ]
 
-    auth._save_stream_cookiejar(jar)
+    _commit(auth, jar)
 
     names = _read_cookie_names(auth._stream_cookies_file)
     assert names == {"yt_cookie"}
 
 
 def test_rejects_cookie_with_embedded_control_character(tmp_path):
-    """_save_stream_cookiejar's own filter loop must reject control chars,
+    """_build_stream_cookiejar's own filter loop must reject control chars,
     not just _cookies_from_raw_header's manual-paste path (SEC-001) --
     the browser-extraction and cookies.txt-import call sites both reach
-    this method directly, so this is the coverage that actually protects
-    them."""
+    it through _commit_session, so this is the coverage that actually
+    protects them."""
     auth = _make_auth(tmp_path)
     jar = [
         _cookie(".youtube.com", name="clean_cookie"),
         _cookie(".youtube.com", name="bad_cookie", value="ab\tcd"),
     ]
 
-    auth._save_stream_cookiejar(jar)
+    _commit(auth, jar)
 
     names = _read_cookie_names(auth._stream_cookies_file)
     assert names == {"clean_cookie"}
@@ -258,20 +275,21 @@ def test_file_mode_is_secure(tmp_path):
         stream_cookies_file=tmp_path / "stream_cookies.txt",
     )
 
-    auth._save_stream_cookiejar([_cookie(".youtube.com")])
+    _commit(auth, [_cookie(".youtube.com")])
 
     mode = (tmp_path / "stream_cookies.txt").stat().st_mode & 0o777
     assert mode == SECURE_FILE_MODE
 
 
-# ── Step 4: independent failure ──────────────────────────────────────────────
+# ── Step 4: failure ordering ─────────────────────────────────────────────────
 
 
-def test_cookiejar_write_failure_does_not_affect_auth_json(tmp_path):
-    """_save_stream_cookiejar's own try/except must swallow a real write
-    failure without affecting auth.json's success signal. Point
-    stream_cookies_file's parent at a directory that never gets created
-    (only config_dir is mkdir'd) so the real internal open() fails."""
+def test_cookiejar_write_failure_stops_the_commit_before_auth_json(tmp_path):
+    """The jar is the first file a commit publishes. When that write fails
+    nothing else is written: auth.json still holds the previous session (or,
+    as here, does not exist yet). Point stream_cookies_file's parent at a
+    directory that never gets created (only config_dir is mkdir'd) so the
+    real internal open() fails."""
     auth = _make_auth(
         tmp_path, stream_cookies_file=tmp_path / "missing_subdir" / "stream_cookies.txt"
     )
@@ -287,33 +305,34 @@ def test_cookiejar_write_failure_does_not_affect_auth_json(tmp_path):
     ):
         result = auth._extract_and_save("vivaldi", interactive=True)
 
-    assert result is True
-    assert auth.auth_file.exists()
+    assert result is False
+    assert not auth.auth_file.exists()
     assert not (tmp_path / "missing_subdir" / "stream_cookies.txt").exists()
     assert not (tmp_path / "missing_subdir").exists()
 
 
-def test_cookiejar_write_failure_removes_previous_jar(tmp_path):
-    """A failed write must not leave the previous session's jar behind:
-    auth.json now belongs to the new session, and streaming would otherwise
-    keep using the old account's cookies."""
+def test_cookiejar_write_failure_keeps_the_previous_jar_and_session(tmp_path):
+    """A failed jar write leaves the previous session complete: its
+    auth.json is not replaced, so its jar still belongs to it and stays."""
     auth = _make_auth(tmp_path)
+    auth.auth_file.write_bytes(b'{"cookie": "SAPISID=old"}')
     auth._stream_cookies_file.write_text("# old account\n", encoding="utf-8")
     jar = [_cookie(".youtube.com", name="SAPISID", value="secret")]
 
     with patch(
         "ytm_player.services.auth._atomic_write", side_effect=OSError("simulated write failure")
     ):
-        result = auth._save_stream_cookiejar(jar)
+        result = _commit(auth, jar)
 
     assert result is False
-    assert not auth._stream_cookies_file.exists()
+    assert auth._stream_cookies_file.read_text(encoding="utf-8") == "# old account\n"
+    assert auth.auth_file.read_bytes() == b'{"cookie": "SAPISID=old"}'
 
 
 def test_cookiejar_write_success_returns_true(tmp_path):
     auth = _make_auth(tmp_path)
 
-    assert auth._save_stream_cookiejar([_cookie(".youtube.com")]) is True
+    assert _commit(auth, [_cookie(".youtube.com")]) is True
     assert auth._stream_cookies_file.exists()
 
 
@@ -324,7 +343,7 @@ def test_no_matching_cookies_writes_empty_jar(tmp_path):
     auth = _make_auth(tmp_path)
     jar = [_cookie(".chase.com"), _cookie("unrelated-shop.example")]
 
-    auth._save_stream_cookiejar(jar)
+    _commit(auth, jar)
 
     assert auth._stream_cookies_file.exists()
     assert _read_cookie_names(auth._stream_cookies_file) == set()
@@ -379,8 +398,8 @@ def test_setup_manual_saves_stream_cookiejar_from_pasted_cookie_header(tmp_path,
     responses = iter(["Host: music.youtube.com", "Cookie: SAPISID=abc123", ""])
     monkeypatch.setattr("builtins.input", lambda: next(responses))
 
-    def _fake_setup(filepath, headers_raw):
-        Path(filepath).write_text('{"cookie": "SAPISID=abc123"}', encoding="utf-8")
+    def _fake_setup(headers_raw=None, filepath=None):
+        return '{"cookie": "SAPISID=abc123", "x-goog-authuser": "0"}'
 
     with (
         patch("ytmusicapi.setup", side_effect=_fake_setup),
@@ -393,22 +412,20 @@ def test_setup_manual_saves_stream_cookiejar_from_pasted_cookie_header(tmp_path,
     assert _read_cookie_names(auth._stream_cookies_file) == {"SAPISID"}
 
 
-def test_no_cookie_header_skips_cookiejar_write(tmp_path, monkeypatch):
+def test_paste_without_cookie_header_is_rejected_and_writes_nothing(tmp_path, monkeypatch):
+    """ytmusicapi itself refuses headers without a cookie (and an
+    x-goog-authuser), so such a paste never reaches a commit."""
     auth = _make_auth(tmp_path)
     responses = iter(["Host: music.youtube.com", "Accept: */*", ""])
     monkeypatch.setattr("builtins.input", lambda: next(responses))
 
-    def _fake_setup(filepath, headers_raw):
-        Path(filepath).write_text('{"cookie": ""}', encoding="utf-8")
-
-    with (
-        patch("ytmusicapi.setup", side_effect=_fake_setup),
-        patch("ytm_player.services.auth.YTMusic", return_value=MagicMock()),
-    ):
+    with patch("ytm_player.services.auth.YTMusic", return_value=MagicMock()):
         result = auth.setup_interactive(manual=True)
 
-    assert result is True
+    assert result is False
+    assert not auth.auth_file.exists()
     assert not auth._stream_cookies_file.exists()
+    assert not auth._account_file.exists()
 
 
 # ── Step 8: account-scoping gate ─────────────────────────────────────────────
@@ -425,84 +442,19 @@ def test_no_valid_account_skips_stream_cookiejar_write(tmp_path):
     with (
         _PATCH_SAPISID,
         patch("ytm_player.services.auth.YTMusic", side_effect=_slot_zero_only(mock_ytm)),
-        patch.object(
-            auth, "_save_stream_cookiejar", wraps=auth._save_stream_cookiejar
-        ) as mock_save,
+        patch.object(auth, "_commit_session", wraps=auth._commit_session) as mock_commit,
     ):
         result = auth._save_youtube_cookies(cookies, interactive=True, stream_jar=stream_jar)
 
     assert result is False
-    mock_save.assert_not_called()
+    mock_commit.assert_not_called()
     assert not auth._stream_cookies_file.exists()
 
 
-# ── Step 9: _refresh_from_cookies_file backup/restore ────────────────────────
+# ── Step 9: _refresh_from_cookies_file probes before it writes ───────────────
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="O_NOFOLLOW is a POSIX-only defense")
-def test_restore_or_remove_does_not_follow_symlink_at_target(tmp_path):
-    """_restore_or_remove's restore branch must use the same O_NOFOLLOW
-    temp-file-plus-os.replace pattern as the primary writes -- a plain
-    write_bytes() would follow a symlink planted at *path* during the
-    network-bound window between backup and restore (found in
-    quality-gate's Layer 1.5 security review)."""
-    target = tmp_path / "auth.json"
-    victim = tmp_path / "victim.txt"
-    victim.write_text("do not touch")
-    target.symlink_to(victim)
-
-    AuthManager._restore_or_remove(target, backup=b'{"cookie": "restored=1"}', label="auth file")
-
-    assert victim.read_text() == "do not touch"
-    assert not target.is_symlink()
-    assert target.read_bytes() == b'{"cookie": "restored=1"}'
-
-
-def test_restore_or_remove_swallows_oserror_from_the_restore_itself(tmp_path, monkeypatch):
-    """_restore_or_remove's own except OSError: branch — what happens
-    when the restore/remove ITSELF fails (e.g. os.replace fails mid-way
-    through _atomic_write) — was untested; the delegation of temp-file
-    cleanup from this method into _atomic_write (quality-gate Layer 1
-    refactor) needs coverage that the failure is still contained here,
-    not just that the happy path still works."""
-    target = tmp_path / "auth.json"
-
-    monkeypatch.setattr(
-        "ytm_player.services.auth.os.replace",
-        MagicMock(side_effect=OSError("simulated replace failure")),
-    )
-
-    AuthManager._restore_or_remove(target, backup=b'{"cookie": "restored=1"}', label="auth file")
-
-    assert not target.exists()
-    assert list(tmp_path.glob("*.tmp-*")) == []
-
-
-def test_restore_or_remove_swallows_oserror_from_removing_with_no_backup(
-    tmp_path, monkeypatch, caplog
-):
-    """The no-prior-backup branch (elif path.exists(): path.unlink()) has
-    its own OSError failure mode, distinct from the restore-with-backup
-    branch above."""
-    target = tmp_path / "auth.json"
-    target.write_text("stale content that should have been removed")
-
-    monkeypatch.setattr(
-        "ytm_player.services.auth.Path.unlink",
-        MagicMock(side_effect=OSError("simulated unlink failure")),
-    )
-
-    with caplog.at_level(logging.WARNING):
-        AuthManager._restore_or_remove(target, backup=None, label="auth file")
-
-    # No exception escapes (calling the method above would have raised if
-    # one did); the failure is logged instead of silently disappearing.
-    assert "Failed to restore previous auth file" in caplog.text
-
-
-def test_refresh_from_cookies_file_restores_stream_cookiejar_on_validate_failure(
-    tmp_path, monkeypatch
-):
+def test_refresh_from_cookies_file_refused_probe_leaves_auth_and_jar_untouched(tmp_path):
     cookies_file = tmp_path / "cookies.txt"
     _write_netscape_cookie_file(cookies_file)
 
@@ -512,10 +464,9 @@ def test_refresh_from_cookies_file_restores_stream_cookiejar_on_validate_failure
     stream_cookies_file.write_text("# sentinel stream cookies\n")
 
     auth = _make_auth(tmp_path, auth_file=auth_file, stream_cookies_file=stream_cookies_file)
-    monkeypatch.setattr(auth, "validate", lambda: False)
 
     mock_ytm = MagicMock()
-    mock_ytm.get_account_info.return_value = {"accountName": "Alice"}
+    mock_ytm.get_account_info.return_value = {}  # no account in any slot
 
     with (
         _PATCH_SAPISID,
@@ -528,9 +479,7 @@ def test_refresh_from_cookies_file_restores_stream_cookiejar_on_validate_failure
     assert stream_cookies_file.read_text() == "# sentinel stream cookies\n"
 
 
-def test_refresh_from_cookies_file_removes_new_stream_cookiejar_when_no_prior_backup(
-    tmp_path, monkeypatch
-):
+def test_refresh_from_cookies_file_refused_probe_on_fresh_install_writes_nothing(tmp_path):
     cookies_file = tmp_path / "cookies.txt"
     _write_netscape_cookie_file(cookies_file)
 
@@ -539,10 +488,9 @@ def test_refresh_from_cookies_file_removes_new_stream_cookiejar_when_no_prior_ba
     # Neither auth_file nor stream_cookies_file exists beforehand.
 
     auth = _make_auth(tmp_path, auth_file=auth_file, stream_cookies_file=stream_cookies_file)
-    monkeypatch.setattr(auth, "validate", lambda: False)
 
     mock_ytm = MagicMock()
-    mock_ytm.get_account_info.return_value = {"accountName": "Alice"}
+    mock_ytm.get_account_info.return_value = {}
 
     with (
         _PATCH_SAPISID,
@@ -553,11 +501,12 @@ def test_refresh_from_cookies_file_removes_new_stream_cookiejar_when_no_prior_ba
     assert result is False
     assert not auth_file.exists()
     assert not stream_cookies_file.exists()
+    assert not auth._account_file.exists()
 
 
 # ── _atomic_write() direct coverage ──────────────────────────────────────────
 #
-# _restore_or_remove and _save_stream_cookiejar only reach _atomic_write's
+# _commit_session only reaches _atomic_write's
 # exception path via failures that occur BEFORE the temp file is created
 # (e.g. a missing parent directory raises in os.open itself) — coverage
 # tools mark the cleanup line as "hit" without ever exercising the actual

--- a/tests/test_services/test_auth_transactions.py
+++ b/tests/test_services/test_auth_transactions.py
@@ -1,0 +1,1082 @@
+"""The sign-in files are updated as one guarded transaction.
+
+auth.json is replaced atomically, account.json is written for exactly those
+bytes, the stream cookiejar is published first and vouched for by hash, and
+an automatic renewal only replaces the session it started from. Readers
+never wait for the lock and never build a client from a half-replaced pair;
+a crash between the writes leaves a whole, usable, unbound session rather
+than an invented identity.
+
+Cross-process behaviour lives in test_auth_lock_process.py; the resolver's
+side of jar vouching in test_stream_resolver_internals.py.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import hashlib
+import json
+import os
+import sys
+import threading
+from http.cookiejar import Cookie
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from ytmusicapi.exceptions import YTMusicServerError
+
+from tests.conftest import make_ytmusic_service
+from tests.test_services.test_auth_identity import account_menu, channel_link
+from ytm_player.services import auth as auth_module
+from ytm_player.services.auth import (
+    AuthManager,
+    SessionBusyError,
+    SessionError,
+    SessionLockTimeoutError,
+    SessionUnreadableError,
+    _atomic_write,
+    _ProbedAccount,
+    _SessionLock,
+    _SessionOwner,
+    read_vouched_stream_jar,
+)
+
+A_ID = "UC" + "a" * 22
+B_ID = "UC" + "b" * 22
+A = _ProbedAccount(slot=0, name="Synthetic A", handle="", channel_id=A_ID)
+B = _ProbedAccount(slot=1, name="Synthetic B", handle="", channel_id=B_ID)
+HEADERS_A = {"cookie": "SAPISID=a; __Secure-3PAPISID=a", "x-goog-authuser": "0"}
+HEADERS_B = {"cookie": "SAPISID=b; __Secure-3PAPISID=b", "x-goog-authuser": "1"}
+EXPIRED = YTMusicServerError("Server returned HTTP 401: Unauthorized.\n")
+
+
+def _payload(headers: dict) -> bytes:
+    return json.dumps(headers, ensure_ascii=True, indent=4, sort_keys=True).encode("utf-8")
+
+
+def _sha(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _cookie(value: str = "a", name: str = "SAPISID") -> Cookie:
+    return Cookie(
+        0,
+        name,
+        value,
+        None,
+        False,
+        ".youtube.com",
+        True,
+        True,
+        "/",
+        True,
+        True,
+        None,
+        False,
+        None,
+        None,
+        {},
+    )
+
+
+def _mgr(tmp_path: Path) -> AuthManager:
+    cfg = tmp_path / "config"
+    cfg.mkdir(exist_ok=True)
+    return AuthManager(
+        config_dir=cfg,
+        auth_file=cfg / "auth.json",
+        cookies_file=None,
+        stream_cookies_file=cfg / "stream_cookies.txt",
+        account_file=cfg / "account.json",
+    )
+
+
+def _commit(mgr: AuthManager, headers: dict, account: _ProbedAccount, jar=None, **kw) -> bool:
+    if jar is None:
+        jar = [_cookie(account.name[-1].lower())]
+    return mgr._commit_session(_payload(headers), account, jar, **kw)
+
+
+def _record(mgr: AuthManager) -> dict:
+    return json.loads(mgr._account_file.read_text(encoding="utf-8"))
+
+
+def _session(mgr: AuthManager) -> tuple[str, str]:
+    return str(mgr.auth_file), str(mgr._account_file)
+
+
+def _vouched(mgr: AuthManager) -> bytes | None:
+    return read_vouched_stream_jar(str(mgr._stream_cookies_file), _session(mgr)).payload
+
+
+def _temps(mgr: AuthManager) -> list[Path]:
+    return sorted(mgr._config_dir.glob("*.tmp-*"))
+
+
+def _files(mgr: AuthManager) -> dict[str, bytes]:
+    """Every file in the config dir except the lock file (created on demand)."""
+    return {p.name: p.read_bytes() for p in mgr._config_dir.iterdir() if p != mgr._lock_path}
+
+
+class _ExpiredClient:
+    """A client whose session has expired; a real class so bound methods carry
+    __self__ (YTMusicService looks the failed client up by it)."""
+
+    def get_account_info(self):
+        raise EXPIRED
+
+    def rate_song(self, *args, **kwargs):
+        raise EXPIRED
+
+
+def _fake_ytmusic(slots: dict[int, _ProbedAccount]):
+    """YTMusic stand-in for the real probe: the account depends on the
+    x-goog-authuser of the file (or dict) the client is built from."""
+
+    def factory(auth, user=None):
+        headers = auth if isinstance(auth, dict) else json.loads(Path(auth).read_text("utf-8"))
+        slot = int(headers["x-goog-authuser"])
+        account = slots.get(slot)
+        if account is None:
+            return _ExpiredClient()
+        client = MagicMock(name=f"client-slot-{slot}")
+        client.get_account_info.return_value = {
+            "accountName": account.name,
+            "channelHandle": account.handle,
+        }
+        client._send_request.return_value = account_menu(channel_link(account.channel_id or ""))
+        return client
+
+    return factory
+
+
+def _paste(monkeypatch, headers: dict) -> None:
+    """Drive _setup_manual with a paste that ytmusicapi turns into *headers*."""
+    lines = iter(["cookie: whatever", ""])
+    monkeypatch.setattr("builtins.input", lambda *a: next(lines))
+    import ytmusicapi
+
+    monkeypatch.setattr(ytmusicapi, "setup", lambda **kw: json.dumps(headers))
+
+
+@contextlib.contextmanager
+def _interrupted_after(writes: int):
+    """Within the block, the (*writes* + 1)-th _atomic_write raises, i.e. the
+    commit crashes after that many files were published. Yields the list of
+    paths written so far. Scoped to its own MonkeyPatch so lifting the fault
+    never lifts a test's other patches (browser/network isolation included)."""
+    real = auth_module._atomic_write
+    written: list[Path] = []
+
+    def flaky(path, *args, **kwargs):
+        if len(written) >= writes:
+            raise OSError(errno.EIO, "interrupted")
+        written.append(path)
+        return real(path, *args, **kwargs)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(auth_module, "_atomic_write", flaky)
+        yield written
+
+
+@pytest.fixture(autouse=True)
+def _no_real_browser_or_network(monkeypatch):
+    """Nothing in this module may reach a browser profile or the network:
+    browser discovery finds nothing, extraction and client construction
+    fail loudly. Tests that need them install their own fakes on top."""
+    monkeypatch.setattr(AuthManager, "_detect_browser", staticmethod(lambda: None))
+
+    def _no_extraction(browser):
+        raise RuntimeError("browser isolation: extraction attempted in a test")
+
+    def _no_network(*args, **kwargs):
+        raise RuntimeError("network isolation: YTMusic constructed in a test")
+
+    monkeypatch.setattr("ytm_player.services.auth._extract_browser_jar", _no_extraction)
+    monkeypatch.setattr("ytm_player.services.auth.YTMusic", _no_network)
+
+
+@pytest.fixture
+def browser(monkeypatch):
+    monkeypatch.setattr(
+        AuthManager,
+        "_detect_browser",
+        staticmethod(lambda: ("brave", [_cookie("a")], [_cookie("a")])),
+    )
+    monkeypatch.setattr("ytm_player.services.auth.sapisid_from_cookie", lambda s: "sapisid")
+    monkeypatch.setattr("ytm_player.services.auth.get_authorization", lambda s: "SAPISIDHASH x")
+
+
+# ── Setup wins, and binds its identity to the bytes it probed ───────────────
+
+
+class TestSetupBindsItsOwnBytes:
+    def test_manual_setup_binds_the_probed_bytes_even_if_another_setup_lands_mid_probe(
+        self, tmp_path, monkeypatch
+    ):
+        """F01: while A's paste is being probed, a setup for B lands. The
+        record must describe A's bytes, and the client built afterwards must
+        carry A's headers with A's identity — never B's headers tagged A."""
+        mgr = _mgr(tmp_path)
+        probed: list[bytes] = []
+
+        def probe(payload, slot):
+            probed.append(payload)
+            assert _commit(mgr, HEADERS_B, B)  # `ytm setup` for B lands now
+            return A
+
+        monkeypatch.setattr(mgr, "_probe_payload", probe)
+        _paste(monkeypatch, HEADERS_A)
+
+        assert mgr._setup_manual() is True
+
+        with patch("ytm_player.services.auth.YTMusic", side_effect=lambda h, **kw: h):
+            client, identity = mgr.create_bound_client()
+        assert (client, identity) == (HEADERS_A, A_ID)
+        assert mgr.auth_file.read_bytes() == probed[0]  # committed == probed bytes
+        assert _record(mgr)["auth_sha256"] == _sha(mgr.auth_file.read_bytes())
+        assert _record(mgr)["verified"] is True
+
+    def test_rejected_paste_leaves_the_working_session_and_its_record(self, tmp_path, monkeypatch):
+        """A5: a paste ytmusicapi rejects changes nothing on disk."""
+        mgr = _mgr(tmp_path)
+        assert _commit(mgr, HEADERS_A, A)
+        before = (mgr.auth_file.read_bytes(), mgr._account_file.read_bytes())
+        lines = iter(["this is not a header block", ""])
+        monkeypatch.setattr("builtins.input", lambda *a: next(lines))
+        import ytmusicapi
+
+        monkeypatch.setattr(
+            ytmusicapi, "setup", lambda **kw: (_ for _ in ()).throw(Exception("bad headers"))
+        )
+
+        assert mgr._setup_manual() is False
+
+        assert (mgr.auth_file.read_bytes(), mgr._account_file.read_bytes()) == before
+        recorded = mgr._load_recorded_identity()
+        assert recorded is not None and recorded.channel_id == A_ID
+
+
+# ── Renewal only replaces the session it started from ───────────────────────
+
+
+class TestRenewalOwnership:
+    def test_setup_landing_during_the_probe_defeats_the_renewal(
+        self, tmp_path, browser, monkeypatch, caplog
+    ):
+        """F02 (setup during refresh): B's setup lands while A's renewal is
+        probing; the renewal refuses and B stays."""
+        mgr = _mgr(tmp_path)
+        assert _commit(mgr, HEADERS_A, A)
+
+        def probe(payload, slot):
+            assert _commit(mgr, HEADERS_B, B)
+            return A
+
+        monkeypatch.setattr(mgr, "_probe_payload", probe)
+
+        with caplog.at_level("WARNING", logger="ytm_player.services.auth"):
+            assert mgr.try_auto_refresh(A_ID) is False
+
+        assert json.loads(mgr.auth_file.read_bytes()) == HEADERS_B
+        assert _record(mgr)["channel_id"] == B_ID
+        assert "changed while it was being renewed" in caplog.text
+
+    def test_browser_fallback_refuses_after_setup_landed_during_the_cookies_file_source(
+        self, tmp_path, browser, monkeypatch
+    ):
+        """F02 (fallback): the owner snapshot is taken once per attempt and
+        carried into the browser fallback, which therefore refuses too."""
+        cfg = tmp_path / "config"
+        cfg.mkdir()
+        mgr = AuthManager(
+            config_dir=cfg,
+            auth_file=cfg / "auth.json",
+            cookies_file=str(tmp_path / "cookies.txt"),
+            stream_cookies_file=cfg / "stream_cookies.txt",
+        )
+        assert _commit(mgr, HEADERS_A, A)
+        reads = MagicMock(wraps=mgr._read_session_pair)
+        monkeypatch.setattr(mgr, "_read_session_pair", reads)
+
+        def cookies_source(*args, **kwargs):
+            assert _commit(mgr, HEADERS_B, B)  # B lands while this source runs
+            return False  # ...and the source itself fails → browser fallback
+
+        monkeypatch.setattr(mgr, "_extract_and_save_from_cookies_file", cookies_source)
+        monkeypatch.setattr(mgr, "_probe_payload", lambda payload, slot: A)
+
+        assert mgr.try_auto_refresh(A_ID) is False
+
+        assert json.loads(mgr.auth_file.read_bytes()) == HEADERS_B
+        assert _record(mgr)["channel_id"] == B_ID
+        assert reads.call_count == 1
+
+    def test_setup_with_byte_identical_headers_still_defeats_the_renewal(
+        self, tmp_path, browser, monkeypatch
+    ):
+        mgr = _mgr(tmp_path)
+        assert _commit(mgr, HEADERS_A, A)
+        setup_revision: list[str] = []
+
+        def probe(payload, slot):
+            # A setup committing exactly the bytes this renewal will commit.
+            assert mgr._commit_session(payload, A, [_cookie("a")])
+            setup_revision.append(_record(mgr)["revision"])
+            return A
+
+        monkeypatch.setattr(mgr, "_probe_payload", probe)
+
+        assert mgr.try_auto_refresh(A_ID) is False
+        assert _record(mgr)["revision"] == setup_revision[0]
+
+    def test_renewal_is_refused_while_another_writer_holds_the_files(
+        self, tmp_path, browser, monkeypatch, caplog
+    ):
+        mgr = _mgr(tmp_path)
+        assert _commit(mgr, HEADERS_A, A)
+        monkeypatch.setattr(
+            mgr, "_read_session_pair", MagicMock(side_effect=SessionBusyError("mid-replacement"))
+        )
+        probe = MagicMock()
+        monkeypatch.setattr(mgr, "_probe_payload", probe)
+
+        with caplog.at_level("WARNING", logger="ytm_player.services.auth"):
+            assert mgr.try_auto_refresh(A_ID) is False
+        probe.assert_not_called()
+        assert "another ytm process is updating the sign-in" in caplog.text
+
+
+# ── Atomic writes and symlinks ──────────────────────────────────────────────
+
+
+class TestAtomicWrite:
+    def test_symlink_at_auth_json_is_refused_and_preserved(self, tmp_path, monkeypatch):
+        """A4: a link planted at auth.json is neither written through nor
+        replaced; the paste fails and the link is still a link."""
+        mgr = _mgr(tmp_path)
+        victim = tmp_path / "victim.txt"
+        victim.write_text("PRECIOUS", encoding="utf-8")
+        try:
+            mgr.auth_file.symlink_to(victim)
+        except OSError as exc:  # pragma: no cover - Windows without the privilege
+            pytest.skip(f"cannot create a symlink here: {exc}")
+        monkeypatch.setattr(mgr, "_probe_payload", lambda payload, slot: A)
+        _paste(monkeypatch, HEADERS_A)
+
+        assert mgr._setup_manual() is False
+
+        assert mgr.auth_file.is_symlink()
+        assert victim.read_text(encoding="utf-8") == "PRECIOUS"
+        assert _temps(mgr) == []
+        with pytest.raises(OSError) as excinfo:
+            _atomic_write(mgr.auth_file, "wb", lambda f: f.write(b"x"))
+        assert excinfo.value.errno == errno.ELOOP
+
+    def test_link_planted_in_the_check_replace_gap_is_replaced_but_its_target_untouched(
+        self, tmp_path, monkeypatch
+    ):
+        """The documented outcome for the one gap left: os.replace never
+        writes through a link, so the target survives; the link entry
+        itself becomes the file."""
+        target = tmp_path / "auth.json"
+        victim = tmp_path / "victim.txt"
+        victim.write_text("PRECIOUS", encoding="utf-8")
+        real_replace = os.replace
+
+        def plant_then_replace(src, dst):
+            try:
+                Path(dst).symlink_to(victim)  # planted after the lstat check
+            except OSError as exc:  # pragma: no cover
+                pytest.skip(f"cannot create a symlink here: {exc}")
+            return real_replace(src, dst)
+
+        monkeypatch.setattr("ytm_player.services.auth.os.replace", plant_then_replace)
+
+        _atomic_write(target, "wb", lambda f: f.write(b"new"))
+
+        assert victim.read_text(encoding="utf-8") == "PRECIOUS"
+        assert not target.is_symlink()
+        assert target.read_bytes() == b"new"
+
+    def test_temp_file_is_created_exclusively_and_a_foreign_file_is_never_removed(
+        self, tmp_path, monkeypatch
+    ):
+        target = tmp_path / "auth.json"
+        monkeypatch.setattr("ytm_player.services.auth.os.urandom", lambda n: b"\0" * n)
+        foreign = tmp_path / f"auth.json.tmp-{os.getpid()}-00000000"
+        foreign.write_text("theirs", encoding="utf-8")
+
+        with pytest.raises(FileExistsError):
+            _atomic_write(target, "wb", lambda f: f.write(b"new"))
+
+        assert foreign.read_text(encoding="utf-8") == "theirs"
+        assert not target.exists()
+
+    def test_partial_auth_write_leaves_the_previous_session_whole(self, tmp_path, monkeypatch):
+        """A3: a write that fails part-way (disk full) leaves auth.json's
+        previous bytes, the record that describes them, and no temp file."""
+        mgr = _mgr(tmp_path)
+        assert _commit(mgr, HEADERS_A, A)
+        before = (mgr.auth_file.read_bytes(), mgr._account_file.read_bytes())
+        real = auth_module._atomic_write
+
+        def flaky(path, mode, write, encoding=None):
+            if path == mgr.auth_file:
+
+                def partial(f):
+                    f.write(b'{"co')
+                    raise OSError(errno.ENOSPC, "No space left on device")
+
+                return real(path, mode, partial, encoding)
+            return real(path, mode, write, encoding)
+
+        monkeypatch.setattr(auth_module, "_atomic_write", flaky)
+
+        assert _commit(mgr, HEADERS_B, B) is False
+
+        assert (mgr.auth_file.read_bytes(), mgr._account_file.read_bytes()) == before
+        assert mgr.is_authenticated() is True
+        recorded = mgr._load_recorded_identity()
+        assert recorded is not None and recorded.channel_id == A_ID
+        assert _temps(mgr) == []
+
+
+# ── Partial publication: every crash state is whole and fail-closed ─────────
+
+
+class TestPartialPublication:
+    def test_crash_after_the_jar_keeps_the_identity_and_refuses_the_jar(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        mgr = _mgr(tmp_path)
+        assert _commit(mgr, HEADERS_A, A)
+        a_auth = mgr.auth_file.read_bytes()
+
+        with _interrupted_after(1):  # strict record → writes: jar, auth, record
+            assert _commit(mgr, HEADERS_B, B) is False
+
+        assert mgr.auth_file.read_bytes() == a_auth
+        recorded = mgr._load_recorded_identity()
+        assert recorded is not None and recorded.channel_id == A_ID
+        with caplog.at_level("WARNING", logger="ytm_player.services.auth"):
+            assert _vouched(mgr) is None
+        assert "does not match the saved sign-in" in caplog.text
+        assert _temps(mgr) == []
+
+    def test_crash_after_auth_yields_an_unbound_session_not_a_busy_one(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        mgr = _mgr(tmp_path)
+        assert _commit(mgr, HEADERS_A, A)
+
+        with _interrupted_after(2):
+            assert _commit(mgr, HEADERS_B, B) is False
+
+        assert json.loads(mgr.auth_file.read_bytes()) == HEADERS_B
+        with caplog.at_level("WARNING", logger="ytm_player.services.auth"):
+            assert mgr._load_recorded_identity() is None  # permanent path, no SessionBusyError
+        assert "does not describe the current auth.json" in caplog.text
+        probe = MagicMock()
+        monkeypatch.setattr(mgr, "_probe_payload", probe)
+        assert mgr.try_auto_refresh() is False
+        probe.assert_not_called()
+        assert _vouched(mgr) is None
+        assert _temps(mgr) == []
+        json.loads(mgr._account_file.read_text(encoding="utf-8"))  # whole
+
+    def test_commit_without_a_jar_removes_the_previous_one(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        assert _commit(mgr, HEADERS_A, A)
+        assert mgr._stream_cookies_file.exists()
+
+        assert mgr._commit_session(_payload(HEADERS_B), B, None) is True
+
+        assert not mgr._stream_cookies_file.exists()
+        assert _record(mgr)["stream_sha256"] is None
+        assert _vouched(mgr) is None
+
+    def test_crash_leftovers_are_never_cleaned_up(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        stale = mgr._config_dir / "auth.json.tmp-1234-deadbeef"
+        stale.write_text("not ours to remove", encoding="utf-8")
+
+        assert _commit(mgr, HEADERS_A, A) is True
+
+        assert stale.read_text(encoding="utf-8") == "not ours to remove"
+
+
+# ── Leaving legacy acceptance before publishing anything ────────────────────
+
+
+class TestLegacyExit:
+    def _legacy(self, tmp_path, form: str) -> AuthManager:
+        mgr = _mgr(tmp_path)
+        mgr.auth_file.write_bytes(_payload(HEADERS_A))
+        mgr._stream_cookies_file.write_bytes(b"# old jar\n")
+        if form == "record_without_key":
+            mgr._account_file.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "x-goog-authuser": "0",
+                        "channel_id": A_ID,
+                        "name": "Synthetic A",
+                        "handle": None,
+                        "auth_sha256": _sha(_payload(HEADERS_A)),
+                    }
+                ),
+                encoding="utf-8",
+            )
+        assert _vouched(mgr) == b"# old jar\n"  # today's trust, before any commit
+        return mgr
+
+    @pytest.mark.parametrize("form", ["no_record", "record_without_key"])
+    def test_interrupted_first_commit_never_accepts_the_new_jar(
+        self, tmp_path, monkeypatch, caplog, form
+    ):
+        mgr = self._legacy(tmp_path, form)
+
+        with _interrupted_after(2):  # writes: transition record, jar, (auth ✗)
+            assert _commit(mgr, HEADERS_B, B, [_cookie("b")]) is False
+
+        assert json.loads(mgr.auth_file.read_bytes()) == HEADERS_A
+        record = _record(mgr)
+        assert record["stream_sha256"] == _sha(b"# old jar\n")
+        assert record["channel_id"] == (A_ID if form == "record_without_key" else None)
+        assert mgr._stream_cookies_file.read_bytes() != b"# old jar\n"
+        with caplog.at_level("WARNING", logger="ytm_player.services.auth"):
+            assert _vouched(mgr) is None
+        assert "does not match the saved sign-in" in caplog.text
+        assert (mgr._load_recorded_identity() is not None) == (form == "record_without_key")
+
+    @pytest.mark.parametrize("form", ["no_record", "record_without_key"])
+    def test_failure_at_the_transition_changes_nothing(self, tmp_path, monkeypatch, form):
+        mgr = self._legacy(tmp_path, form)
+        before = _files(mgr)
+
+        with _interrupted_after(0):
+            assert _commit(mgr, HEADERS_B, B, [_cookie("b")]) is False
+
+        assert _files(mgr) == before
+        assert _vouched(mgr) == b"# old jar\n"
+
+    @pytest.mark.parametrize("form", ["no_record", "record_without_key"])
+    def test_successful_first_commit_records_the_jar_and_a_revision(self, tmp_path, form):
+        mgr = self._legacy(tmp_path, form)
+
+        assert _commit(mgr, HEADERS_B, B, [_cookie("b")]) is True
+
+        record = _record(mgr)
+        assert record["stream_sha256"] == _sha(mgr._stream_cookies_file.read_bytes())
+        assert len(record["revision"]) == 32
+        assert _vouched(mgr) == mgr._stream_cookies_file.read_bytes()
+
+    def test_legacy_install_without_a_jar_records_null(self, tmp_path, monkeypatch):
+        mgr = _mgr(tmp_path)
+        mgr.auth_file.write_bytes(_payload(HEADERS_A))
+
+        with _interrupted_after(1):
+            assert _commit(mgr, HEADERS_B, B, [_cookie("b")]) is False
+
+        assert _record(mgr)["stream_sha256"] is None
+        assert _record(mgr)["auth_sha256"] == _sha(_payload(HEADERS_A))
+        assert _vouched(mgr) is None
+
+    @pytest.mark.parametrize(
+        "content",
+        [b"{broken", json.dumps({"schema_version": 2, "channel_id": A_ID}).encode()],
+        ids=["malformed", "unknown_schema"],
+    )
+    def test_invalid_record_is_replaced_by_one_that_vouches_for_nothing(
+        self, tmp_path, caplog, content
+    ):
+        """Only genuine legacy shapes inherit today's jar trust. A record that
+        exists but does not parse (or is of another schema) refused the jar
+        before; after a commit that fails right after the transition it must
+        still refuse it — the provisional record vouches for no jar."""
+        mgr = _mgr(tmp_path)
+        mgr.auth_file.write_bytes(_payload(HEADERS_A))
+        mgr._stream_cookies_file.write_bytes(b"# unvouched jar\n")
+        mgr._account_file.write_bytes(content)
+        assert _vouched(mgr) is None
+
+        with caplog.at_level("WARNING", logger="ytm_player.services.auth"):
+            with _interrupted_after(1):  # transition record published, jar ✗
+                assert _commit(mgr, HEADERS_B, B, [_cookie("b")]) is False
+
+        record = _record(mgr)
+        assert (record["stream_sha256"], record["channel_id"], record["verified"]) == (
+            None,
+            None,
+            False,
+        )
+        assert record["auth_sha256"] == _sha(_payload(HEADERS_A))
+        assert _vouched(mgr) is None
+        assert mgr._load_recorded_identity() is None
+        assert "was malformed; replaced it with a record that vouches for no" in caplog.text
+
+    def test_unreadable_record_fails_the_commit(self, tmp_path, monkeypatch, caplog):
+        mgr = _mgr(tmp_path)
+        assert _commit(mgr, HEADERS_A, A)
+        before = _files(mgr)
+        monkeypatch.setattr(
+            mgr, "_read_record_raw", MagicMock(side_effect=PermissionError("unreadable"))
+        )
+
+        with caplog.at_level("ERROR", logger="ytm_player.services.auth"):
+            assert _commit(mgr, HEADERS_B, B) is False
+
+        assert _files(mgr) == before
+        assert "while reading the current sign-in" in caplog.text
+
+    def test_strict_record_skips_the_transition(self, tmp_path, monkeypatch):
+        mgr = _mgr(tmp_path)
+        assert _commit(mgr, HEADERS_A, A)
+
+        with _interrupted_after(99) as written:
+            assert _commit(mgr, HEADERS_B, B) is True
+
+        assert written.count(mgr._account_file) == 1  # step 3 only
+
+
+# ── Fresh install: strict metadata exists before anything is published ──────
+
+
+class TestFreshInstall:
+    # _atomic_write calls on a fresh install: provisional record, jar, auth, record.
+    @pytest.mark.parametrize("published", [1, 2, 3])
+    def test_candidate_jar_is_refused_until_the_commit_completes(
+        self, tmp_path, monkeypatch, caplog, published
+    ):
+        mgr = _mgr(tmp_path)
+        assert not any(mgr._config_dir.iterdir())
+
+        with _interrupted_after(published):
+            assert _commit(mgr, HEADERS_A, A) is False
+
+        fresh = _mgr(tmp_path)
+        record = _record(fresh)
+        assert (record["channel_id"], record["verified"]) == (None, False)
+        assert (record["auth_sha256"], record["stream_sha256"]) == (None, None)
+        assert "revision" not in record
+        with caplog.at_level("WARNING", logger="ytm_player.services.auth"):
+            assert _vouched(fresh) is None
+            with patch("ytm_player.services.auth.YTMusic", side_effect=lambda h, **kw: h) as ctor:
+                client, identity = fresh.create_bound_client()
+        assert identity is None
+        if published >= 3:  # auth.json is there: unbound, never busy
+            assert client == HEADERS_A
+            assert "does not describe the current auth.json" in caplog.text
+        else:  # no auth.json yet: today's path-based fallback
+            assert ctor.call_args.args[0] == str(fresh.auth_file)
+        assert fresh.try_auto_refresh() is False
+
+        assert _commit(fresh, HEADERS_A, A) is True
+        assert _vouched(fresh) == fresh._stream_cookies_file.read_bytes()
+        recorded = fresh._load_recorded_identity()
+        assert recorded is not None and recorded.channel_id == A_ID
+
+
+# ── Recovery through the real service ───────────────────────────────────────
+
+
+class TestRecoveryThroughTheService:
+    async def test_crash_after_auth_replacement_leaves_a_working_unbound_session(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        mgr = _mgr(tmp_path)
+        assert _commit(mgr, HEADERS_A, A)
+        with _interrupted_after(2):
+            assert _commit(mgr, HEADERS_B, B) is False
+
+        fresh = _mgr(tmp_path)  # restart
+        refresh = MagicMock(return_value=True)
+        monkeypatch.setattr(fresh, "try_auto_refresh", refresh)
+        service = make_ytmusic_service(_ytm=None, _auth_manager=fresh)
+        monkeypatch.setattr("ytm_player.services.auth.YTMusic", _fake_ytmusic({}))
+
+        with caplog.at_level("WARNING"):
+            assert await service.rate_song("vid", "LIKE") == "auth_expired"
+
+        assert service._client_identities[service.client] is None
+        refresh.assert_not_called()
+        assert "does not describe the current auth.json" in caplog.text
+        assert "no recorded account identity" in caplog.text
+
+        # `ytm setup` is the recovery: the next client carries the identity.
+        monkeypatch.setattr(fresh, "_probe_payload", lambda payload, slot: B)
+        _paste(monkeypatch, HEADERS_B)
+        assert fresh._setup_manual() is True
+        service._ytm = None
+        assert service._client_identities[service.client] == B_ID
+
+    async def test_crash_after_the_jar_keeps_renewal_working(self, tmp_path, browser, monkeypatch):
+        mgr = _mgr(tmp_path)
+        assert _commit(mgr, HEADERS_A, A)
+        with _interrupted_after(1):
+            assert _commit(mgr, HEADERS_B, B) is False
+
+        fresh = _mgr(tmp_path)
+        assert _vouched(fresh) is None
+        monkeypatch.setattr("ytm_player.services.auth.YTMusic", _fake_ytmusic({0: A}))
+
+        assert fresh.try_auto_refresh(A_ID) is True
+
+        assert _vouched(fresh) == fresh._stream_cookies_file.read_bytes()
+        recorded = fresh._load_recorded_identity()
+        assert recorded is not None and recorded.channel_id == A_ID
+
+
+# ── Readers: consistent snapshot, never waiting, never an OSError ────────────
+
+
+class TestReaders:
+    def test_session_exceptions_are_not_oserrors(self):
+        for exc in (SessionBusyError("x"), SessionLockTimeoutError("x")):
+            assert isinstance(exc, SessionError)
+            assert isinstance(exc, RuntimeError)
+            assert not isinstance(exc, OSError)
+
+    def test_missing_auth_file_keeps_the_path_based_fallback(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        with patch("ytm_player.services.auth.YTMusic", side_effect=lambda h, **kw: h) as ctor:
+            client, identity = mgr.create_bound_client()
+        assert (client, identity) == (str(mgr.auth_file), None)
+        ctor.assert_called_once()
+
+    @pytest.mark.parametrize("lock_state", ["free", "held"])
+    def test_unreadable_record_refuses_and_is_never_absent(self, tmp_path, monkeypatch, lock_state):
+        """A record that exists but cannot be read is not "no record": the
+        public method raises SessionUnreadableError (never an OSError, never
+        an unbound client) whether or not a writer holds the lock."""
+        mgr = _mgr(tmp_path)
+        assert _commit(mgr, HEADERS_A, A)
+        monkeypatch.setattr(
+            mgr, "_read_record_raw", MagicMock(side_effect=PermissionError("unreadable"))
+        )
+        holder = _SessionLock(_mgr(tmp_path)._lock_path)
+        held, release = threading.Event(), threading.Event()
+
+        def hold():
+            holder.acquire(timeout=5)
+            held.set()
+            release.wait(5)
+            holder.release()
+
+        thread = threading.Thread(target=hold) if lock_state == "held" else None
+        if thread is not None:
+            thread.start()
+            assert held.wait(5)
+        try:
+            with patch("ytm_player.services.auth.YTMusic") as ctor:
+                with pytest.raises(SessionUnreadableError) as excinfo:
+                    mgr.create_bound_client()
+            ctor.assert_not_called()
+            assert not isinstance(excinfo.value, OSError)
+            assert mgr._load_recorded_identity() is None
+            assert mgr.try_auto_refresh() is False
+        finally:
+            release.set()
+            if thread is not None:
+                thread.join(5)
+
+    async def test_unreadable_record_reaches_the_services_safe_default(self, tmp_path, monkeypatch):
+        mgr = _mgr(tmp_path)
+        assert _commit(mgr, HEADERS_A, A)
+        monkeypatch.setattr(
+            mgr, "_read_record_raw", MagicMock(side_effect=PermissionError("unreadable"))
+        )
+        service = make_ytmusic_service(_ytm=None, _auth_manager=mgr)
+
+        assert await service.get_home() is None
+        assert service._ytm is None
+
+    def test_malformed_record_is_an_unbound_session_with_a_warning(self, tmp_path, caplog):
+        mgr = _mgr(tmp_path)
+        assert _commit(mgr, HEADERS_A, A)
+        mgr._account_file.write_bytes(b"{broken")
+
+        with caplog.at_level("WARNING", logger="ytm_player.services.auth"):
+            with patch("ytm_player.services.auth.YTMusic", side_effect=lambda h, **kw: h):
+                client, identity = mgr.create_bound_client()
+        assert (client, identity) == (HEADERS_A, None)
+        assert "account.json is malformed; ignoring it" in caplog.text
+
+    def test_contention_raises_session_busy_and_builds_no_client(self, tmp_path, monkeypatch):
+        """Another thread (a second manager for the same files) holds the lock
+        while the pair is inconsistent: the public method raises SessionBusyError,
+        and no client is constructed — not even an unbound one."""
+        mgr = _mgr(tmp_path)
+        assert _commit(mgr, HEADERS_A, A)
+        mgr.auth_file.write_bytes(_payload(HEADERS_B))  # mid-commit shape
+        holder = _mgr(tmp_path)
+        lock = _SessionLock(holder._lock_path)
+        held, release = threading.Event(), threading.Event()
+
+        def hold():
+            lock.acquire(timeout=5)
+            held.set()
+            release.wait(5)
+            lock.release()
+
+        thread = threading.Thread(target=hold)
+        thread.start()
+        try:
+            assert held.wait(5)
+            with patch("ytm_player.services.auth.YTMusic") as ctor:
+                with pytest.raises(SessionBusyError):
+                    mgr.create_bound_client()
+            ctor.assert_not_called()
+        finally:
+            release.set()
+            thread.join(5)
+
+        # Lock free again: the same pair is a permanent leftover → unbound.
+        with patch("ytm_player.services.auth.YTMusic", side_effect=lambda h, **kw: h):
+            client, identity = mgr.create_bound_client()
+        assert (client, identity) == (HEADERS_B, None)
+
+    async def test_session_busy_propagates_to_the_services_safe_default(
+        self, tmp_path, monkeypatch
+    ):
+        mgr = _mgr(tmp_path)
+        assert _commit(mgr, HEADERS_A, A)
+        monkeypatch.setattr(mgr, "_read_session_pair", MagicMock(side_effect=SessionBusyError("x")))
+        refresh = MagicMock()
+        monkeypatch.setattr(mgr, "try_auto_refresh", refresh)
+        service = make_ytmusic_service(_ytm=None, _auth_manager=mgr)
+
+        assert await service.get_home() is None
+        refresh.assert_not_called()
+        assert service._ytm is None  # the next call retries the read
+
+    def test_owner_snapshot_carries_hash_and_revision(self, tmp_path):
+        mgr = _mgr(tmp_path)
+        assert _commit(mgr, HEADERS_A, A)
+        pair = mgr._read_session_pair()
+        assert pair.owner == _SessionOwner(
+            _sha(mgr.auth_file.read_bytes()), _record(mgr)["revision"]
+        )
+
+
+# ── The in-process lock: per path, shared by managers, not re-entrant ───────
+
+
+class TestInProcessLock:
+    def test_second_manager_waits_for_the_first_and_nesting_raises(self, tmp_path):
+        mgr1, mgr2 = _mgr(tmp_path), _mgr(tmp_path)
+        order: list[str] = []
+        a_holds, a_release = threading.Event(), threading.Event()
+
+        def thread_a():
+            lock = _SessionLock(mgr1._lock_path)
+            lock.acquire(timeout=5)
+            a_holds.set()
+            with pytest.raises(RuntimeError, match="not re-entrant"):
+                _SessionLock(mgr2._lock_path).acquire(timeout=5)  # same thread, other manager
+            a_release.wait(5)
+            order.append("A-release")
+            lock.release()
+
+        def thread_b():
+            lock = _SessionLock(mgr2._lock_path)
+            lock.acquire(timeout=5)
+            order.append("B-acquired")
+            lock.release()
+
+        ta = threading.Thread(target=thread_a)
+        ta.start()
+        assert a_holds.wait(5)
+        tb = threading.Thread(target=thread_b)
+        tb.start()
+        a_release.set()
+        ta.join(5)
+        tb.join(5)
+
+        assert order == ["A-release", "B-acquired"]
+        assert mgr1._lock_path.exists()  # never unlinked
+
+    def test_timeout_covers_the_thread_level_lock(self, tmp_path):
+        mgr1, mgr2 = _mgr(tmp_path), _mgr(tmp_path)
+        held, release = threading.Event(), threading.Event()
+
+        def hold():
+            lock = _SessionLock(mgr1._lock_path)
+            lock.acquire(timeout=5)
+            held.set()
+            release.wait(5)
+            lock.release()
+
+        thread = threading.Thread(target=hold)
+        thread.start()
+        try:
+            assert held.wait(5)
+            with pytest.raises(SessionLockTimeoutError):
+                _SessionLock(mgr2._lock_path).acquire(timeout=0.2)
+        finally:
+            release.set()
+            thread.join(5)
+
+    def test_symlink_at_the_lock_path_is_refused(self, tmp_path, caplog):
+        mgr = _mgr(tmp_path)
+        victim = tmp_path / "victim.txt"
+        victim.write_text("x", encoding="utf-8")
+        try:
+            mgr._lock_path.symlink_to(victim)
+        except OSError as exc:  # pragma: no cover
+            pytest.skip(f"cannot create a symlink here: {exc}")
+
+        with caplog.at_level("WARNING", logger="ytm_player.services.auth"):
+            assert _commit(mgr, HEADERS_A, A) is False
+        assert "Cannot lock the sign-in files" in caplog.text
+        assert not mgr.auth_file.exists()
+
+
+# ── read_vouched_stream_jar ─────────────────────────────────────────────────
+
+
+class TestReadVouchedStreamJar:
+    def _files(self, tmp_path, *, jar=b"# jar\n", auth=b'{"cookie": "SAPISID=a"}', record="strict"):
+        jar_path, auth_path, record_path = (
+            tmp_path / "stream_cookies.txt",
+            tmp_path / "auth.json",
+            tmp_path / "account.json",
+        )
+        if jar is not None:
+            jar_path.write_bytes(jar)
+        if auth is not None:
+            auth_path.write_bytes(auth)
+        if record == "strict":
+            record_path.write_text(
+                json.dumps(
+                    {"schema_version": 1, "auth_sha256": _sha(auth), "stream_sha256": _sha(jar)}
+                )
+            )
+        elif isinstance(record, dict):
+            record_path.write_text(json.dumps(record))
+        elif record == "malformed":
+            record_path.write_text("{not json")
+        return str(jar_path), (str(auth_path), str(record_path))
+
+    def test_vouched_jar_is_returned_with_the_snapshots_signature(self, tmp_path):
+        jar_path, session = self._files(tmp_path)
+        result = read_vouched_stream_jar(jar_path, session)
+        assert result.payload == b"# jar\n"
+        stats = tuple(
+            (st.st_ino, st.st_mtime_ns, st.st_size)
+            for st in (os.stat(jar_path), os.stat(session[0]), os.stat(session[1]))
+        )
+        assert result.signature == (jar_path, *stats)
+
+    def test_legacy_forms_are_accepted(self, tmp_path):
+        jar_path, session = self._files(tmp_path, record=None)
+        assert read_vouched_stream_jar(jar_path, session).payload == b"# jar\n"
+        jar_path, session = self._files(
+            tmp_path, record={"schema_version": 1, "auth_sha256": _sha(b'{"cookie": "SAPISID=a"}')}
+        )
+        assert read_vouched_stream_jar(jar_path, session).payload == b"# jar\n"
+
+    @pytest.mark.parametrize(
+        "case, reason",
+        [
+            ("no_auth", "auth.json is missing"),
+            ("other_auth", "does not describe the current auth.json"),
+            ("null", "has no stream cookie file"),
+            ("mismatch", "does not match the saved sign-in"),
+            ("malformed", "account.json is malformed"),
+            ("no_session", "no sign-in files to check it against"),
+        ],
+    )
+    def test_refusals_name_their_reason(self, tmp_path, caplog, case, reason):
+        auth = b'{"cookie": "SAPISID=a"}'
+        if case == "no_auth":
+            jar_path, session = self._files(tmp_path, auth=None, record=None)
+        elif case == "other_auth":
+            jar_path, session = self._files(
+                tmp_path,
+                record={"schema_version": 1, "auth_sha256": _sha(b"other"), "stream_sha256": None},
+            )
+        elif case == "null":
+            jar_path, session = self._files(
+                tmp_path,
+                record={"schema_version": 1, "auth_sha256": _sha(auth), "stream_sha256": None},
+            )
+        elif case == "mismatch":
+            jar_path, session = self._files(
+                tmp_path,
+                record={"schema_version": 1, "auth_sha256": _sha(auth), "stream_sha256": "00"},
+            )
+        elif case == "malformed":
+            jar_path, session = self._files(tmp_path, record="malformed")
+        else:
+            jar_path, session = self._files(tmp_path)
+            session = None
+
+        with caplog.at_level("WARNING", logger="ytm_player.services.auth"):
+            result = read_vouched_stream_jar(jar_path, session)
+        assert result.payload is None
+        assert reason in caplog.text
+        assert caplog.text.count("Stream cookie file") == 1
+
+    @pytest.mark.parametrize("which", ["record", "auth", "jar"])
+    def test_unreadable_file_refuses_even_when_absence_would_be_legacy(
+        self, tmp_path, monkeypatch, caplog, which
+    ):
+        """Astra's reproduction: a strict record with ``stream_sha256`` null
+        forbids the jar; making that record unreadable must not turn it into
+        an absent (legacy, accepting) one. Same for the other two files."""
+        auth = b'{"cookie": "SAPISID=a"}'
+        record = {"schema_version": 1, "auth_sha256": _sha(auth), "stream_sha256": None}
+        jar_path, session = self._files(tmp_path, auth=auth, record=record)
+        if which == "auth":  # a legacy-shaped pair, so only the read error can refuse
+            (tmp_path / "account.json").unlink()
+        target = {"record": session[1], "auth": session[0], "jar": jar_path}[which]
+        real_open = open
+
+        def unreadable(path, *args, **kwargs):
+            if str(path) == target:
+                raise PermissionError("synthetic unreadable file")
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(auth_module, "open", unreadable, raising=False)
+
+        with caplog.at_level("WARNING", logger="ytm_player.services.auth"):
+            result = read_vouched_stream_jar(jar_path, session)
+        assert result.payload is None
+        expected = {
+            "record": "account.json cannot be read",
+            "auth": "auth.json is unreadable",
+            "jar": "the stream cookie file is unreadable",
+        }[which]
+        assert expected in caplog.text
+
+    def test_record_changing_between_the_two_reads_refuses(self, tmp_path, monkeypatch, caplog):
+        jar_path, session = self._files(tmp_path)
+        real = auth_module._read_with_stat
+        record_reads = [0]
+
+        def flip(path):
+            read = real(path)
+            if str(path) == session[1]:
+                record_reads[0] += 1
+                if record_reads[0] % 2 == 0 and read.data is not None:
+                    read = auth_module._FileRead(read.data + b" ", read.stat)
+            return read
+
+        monkeypatch.setattr(auth_module, "_read_with_stat", flip)
+        with caplog.at_level("WARNING", logger="ytm_player.services.auth"):
+            result = read_vouched_stream_jar(jar_path, session)
+        assert result.payload is None
+        assert "changed while they were being checked" in caplog.text
+        assert record_reads[0] == 6  # three attempts
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file modes")
+def test_lock_file_and_written_files_are_private(tmp_path):
+    mgr = _mgr(tmp_path)
+    assert _commit(mgr, HEADERS_A, A)
+    for path in (mgr._lock_path, mgr.auth_file, mgr._account_file, mgr._stream_cookies_file):
+        assert path.stat().st_mode & 0o777 == 0o600, path

--- a/tests/test_services/test_stream.py
+++ b/tests/test_services/test_stream.py
@@ -12,7 +12,7 @@ from ytm_player.services.stream import StreamInfo, StreamResolver
 
 
 @pytest.fixture(autouse=True)
-def _no_real_cookie_detection(monkeypatch):
+def _no_real_cookie_detection(monkeypatch, tmp_path):
     """_build_ydl_opts() calls _detect_stream_cookies() for real whenever
     cookiefile isn't already configured (the default — see
     YtDlpSettings.cookies_file) — and that function checks whether
@@ -22,9 +22,17 @@ def _no_real_cookie_detection(monkeypatch):
     yt_dlp.YoutubeDL mocked, so without stubbing this out, a routine test
     run could pick up a real cookiejar file from the developer's actual
     ~/.config/ytm-player/ — the side effect this project's test suite is
-    built to avoid.
+    built to avoid. The sign-in files a jar would be checked against are
+    pointed at a scratch pair for the same reason.
     """
     monkeypatch.setattr("ytm_player.services.stream._detect_stream_cookies", lambda: None)
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    (session_dir / "auth.json").write_text('{"cookie": "SAPISID=x"}', encoding="utf-8")
+    monkeypatch.setattr(
+        "ytm_player.services.stream._detect_session_record",
+        lambda: (str(session_dir / "auth.json"), str(session_dir / "account.json")),
+    )
 
 
 def _make_info(video_id: str = "test123", ttl: float = 18000) -> StreamInfo:

--- a/tests/test_services/test_stream_resolver_internals.py
+++ b/tests/test_services/test_stream_resolver_internals.py
@@ -319,7 +319,9 @@ class TestStreamCookiejarLoading:
         # Loaded from the bytes that were checked, not by re-reading the path.
         ydl.cookiejar.load.assert_called_once()
         loaded, kwargs = ydl.cookiejar.load.call_args
-        assert loaded[0].getvalue() == jar.read_text(encoding="utf-8")
+        assert loaded[0].getvalue() == jar.read_bytes().decode(
+            "utf-8"
+        )  # exact bytes, no newline translation
         assert kwargs == {"ignore_discard": True, "ignore_expires": True}
         assert resolver._ydl_cookiejar_sig is not None
         assert resolver._ydl_cookiejar_sig[0] == str(jar)
@@ -375,7 +377,9 @@ class TestStreamCookiejarLoading:
         assert second is not first
         first.close.assert_called_once()
         second.cookiejar.load.assert_called_once()
-        assert second.cookiejar.load.call_args.args[0].getvalue() == jar.read_text(encoding="utf-8")
+        assert second.cookiejar.load.call_args.args[0].getvalue() == jar.read_bytes().decode(
+            "utf-8"
+        )
 
     def test_rewritten_jar_is_ignored_when_anonymous(self, tmp_path, monkeypatch):
         self._settings(monkeypatch)
@@ -495,7 +499,7 @@ class TestStreamCookiejarVouching:
         jar = session_dir / "stream_cookies.txt"
         auth = session_dir / "auth.json"
         record = session_dir / "account.json"
-        jar.write_text(self.JAR, encoding="utf-8")
+        jar.write_bytes(self.JAR.encode("utf-8"))  # exact bytes on every platform
         auth.write_bytes(self.AUTH)
         record.write_text(
             json.dumps(
@@ -576,7 +580,7 @@ class TestStreamCookiejarVouching:
             elif changed == "record":
                 record.write_text(json.dumps({"schema_version": 1}), encoding="utf-8")
             else:
-                jar.write_text(self.JAR + "# extra\n", encoding="utf-8")
+                jar.write_bytes((self.JAR + "# extra\n").encode("utf-8"))
             second = resolver._get_ydl()
         finally:
             patcher.stop()

--- a/tests/test_services/test_stream_resolver_internals.py
+++ b/tests/test_services/test_stream_resolver_internals.py
@@ -11,6 +11,7 @@ These guard against bugs confirmed in practice during development:
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -20,10 +21,20 @@ from ytm_player.services.stream import StreamResolver, _detect_stream_cookies
 
 
 @pytest.fixture(autouse=True)
-def _no_real_cookie_detection(monkeypatch):
+def _no_real_cookie_detection(monkeypatch, tmp_path):
     """_get_ydl() stats the real stream cookiejar path unless stubbed; tests
-    that want a jar patch _detect_stream_cookies explicitly."""
+    that want a jar patch _detect_stream_cookies explicitly. The sign-in
+    files a jar is checked against are pointed at a scratch pair shaped like
+    an install that has not committed since upgrading (auth.json present, no
+    account.json), so an injected jar is accepted under the legacy rule."""
     monkeypatch.setattr("ytm_player.services.stream._detect_stream_cookies", lambda: None)
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    (session_dir / "auth.json").write_text('{"cookie": "SAPISID=x"}', encoding="utf-8")
+    monkeypatch.setattr(
+        "ytm_player.services.stream._detect_session_record",
+        lambda: (str(session_dir / "auth.json"), str(session_dir / "account.json")),
+    )
 
 
 class TestDetectStreamCookies:
@@ -305,9 +316,11 @@ class TestStreamCookiejarLoading:
             resolver = StreamResolver()
             ydl = resolver._get_ydl()
         assert "cookiefile" not in fake_class.call_args.args[0]
-        ydl.cookiejar.load.assert_called_once_with(
-            str(jar), ignore_discard=True, ignore_expires=True
-        )
+        # Loaded from the bytes that were checked, not by re-reading the path.
+        ydl.cookiejar.load.assert_called_once()
+        loaded, kwargs = ydl.cookiejar.load.call_args
+        assert loaded[0].getvalue() == jar.read_text(encoding="utf-8")
+        assert kwargs == {"ignore_discard": True, "ignore_expires": True}
         assert resolver._ydl_cookiejar_sig is not None
         assert resolver._ydl_cookiejar_sig[0] == str(jar)
 
@@ -361,9 +374,8 @@ class TestStreamCookiejarLoading:
 
         assert second is not first
         first.close.assert_called_once()
-        second.cookiejar.load.assert_called_once_with(
-            str(jar), ignore_discard=True, ignore_expires=True
-        )
+        second.cookiejar.load.assert_called_once()
+        assert second.cookiejar.load.call_args.args[0].getvalue() == jar.read_text(encoding="utf-8")
 
     def test_rewritten_jar_is_ignored_when_anonymous(self, tmp_path, monkeypatch):
         self._settings(monkeypatch)
@@ -462,3 +474,141 @@ class TestClientAndFormatSelection:
         ydl = yt_dlp.YoutubeDL({"quiet": True})
         for selector in QUALITY_FORMATS.values():
             ydl.build_format_selector(selector)  # raises SyntaxError if malformed
+
+
+class TestStreamCookiejarVouching:
+    """With ``[yt_dlp] use_session_cookies`` on, the resolver loads the jar
+    only when the sign-in record for the current auth.json vouches for it by
+    hash (auth.read_vouched_stream_jar). The cached signature covers all
+    three files, so a change to any one of them — auth.json alone included —
+    rebuilds the instance and reruns the check; and it is the signature of
+    the exact snapshot that was checked, never a separate stat."""
+
+    AUTH = b'{"cookie": "SAPISID=x", "x-goog-authuser": "0"}'
+    JAR = "# Netscape HTTP Cookie File\n.youtube.com\tTRUE\t/\tTRUE\t2147483647\tSAPISID\tabc\n"
+
+    def _pair(self, tmp_path, monkeypatch, *, vouched=True):
+        import hashlib
+
+        session_dir = tmp_path / "vouched"
+        session_dir.mkdir()
+        jar = session_dir / "stream_cookies.txt"
+        auth = session_dir / "auth.json"
+        record = session_dir / "account.json"
+        jar.write_text(self.JAR, encoding="utf-8")
+        auth.write_bytes(self.AUTH)
+        record.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "auth_sha256": hashlib.sha256(self.AUTH).hexdigest(),
+                    "stream_sha256": hashlib.sha256(jar.read_bytes()).hexdigest()
+                    if vouched
+                    else "00",
+                }
+            ),
+            encoding="utf-8",
+        )
+        settings = Settings()
+        settings.yt_dlp.use_session_cookies = True
+        monkeypatch.setattr("ytm_player.services.stream.get_settings", lambda: settings)
+        monkeypatch.setattr("ytm_player.services.stream._detect_stream_cookies", lambda: str(jar))
+        monkeypatch.setattr(
+            "ytm_player.services.stream._detect_session_record",
+            lambda: (str(auth), str(record)),
+        )
+        return jar, auth, record
+
+    def _resolver(self):
+        fake_class = MagicMock(side_effect=lambda opts: MagicMock())
+        patcher = patch("yt_dlp.YoutubeDL", fake_class)
+        patcher.start()
+        return StreamResolver(), patcher
+
+    @staticmethod
+    def _loaded(ydl) -> str | None:
+        if not ydl.cookiejar.load.called:
+            return None
+        return ydl.cookiejar.load.call_args.args[0].getvalue()
+
+    def test_vouched_jar_is_loaded_from_the_checked_bytes(self, tmp_path, monkeypatch):
+        jar, auth, record = self._pair(tmp_path, monkeypatch)
+        resolver, patcher = self._resolver()
+        try:
+            ydl = resolver._get_ydl()
+        finally:
+            patcher.stop()
+        assert self._loaded(ydl) == self.JAR
+        from ytm_player.services.auth import read_vouched_stream_jar
+
+        checked = read_vouched_stream_jar(str(jar), (str(auth), str(record)))
+        assert resolver._ydl_cookiejar_sig == checked.signature
+
+    def test_unvouched_jar_is_refused_once_and_the_instance_reused(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        self._pair(tmp_path, monkeypatch, vouched=False)
+        resolver, patcher = self._resolver()
+        try:
+            with caplog.at_level("WARNING", logger="ytm_player.services.auth"):
+                first = resolver._get_ydl()
+                resolver._active_resolves -= 1
+                second = resolver._get_ydl()
+        finally:
+            patcher.stop()
+        assert second is first
+        assert self._loaded(first) is None
+        assert caplog.text.count("Stream cookie file") == 1  # no rebuild churn
+        assert resolver._ydl_cookiejar_sig is not None
+
+    @pytest.mark.parametrize("changed", ["auth", "record", "jar"])
+    def test_a_change_to_any_sign_in_file_rebuilds_and_rechecks(
+        self, tmp_path, monkeypatch, changed
+    ):
+        jar, auth, record = self._pair(tmp_path, monkeypatch)
+        resolver, patcher = self._resolver()
+        try:
+            first = resolver._get_ydl()
+            resolver._active_resolves -= 1
+            assert self._loaded(first) == self.JAR
+            if changed == "auth":
+                auth.write_bytes(b'{"cookie": "SAPISID=other", "x-goog-authuser": "0"}')
+            elif changed == "record":
+                record.write_text(json.dumps({"schema_version": 1}), encoding="utf-8")
+            else:
+                jar.write_text(self.JAR + "# extra\n", encoding="utf-8")
+            second = resolver._get_ydl()
+        finally:
+            patcher.stop()
+        assert second is not first
+        assert self._loaded(second) is None  # rechecked: no longer vouched
+
+    def test_cached_signature_is_the_reads_own_snapshot(self, tmp_path, monkeypatch):
+        """A commit landing between the vouching read and the cache update
+        must not be described by the cached signature: the next _get_ydl
+        sees a difference and rebuilds instead of keeping a stale jar."""
+        jar, auth, record = self._pair(tmp_path, monkeypatch)
+        from ytm_player.services import auth as auth_module
+
+        real_read = auth_module.read_vouched_stream_jar
+        snapshots = []
+
+        def read_then_commit(jar_path, session):
+            result = real_read(jar_path, session)
+            snapshots.append(result.signature)
+            record.write_text(json.dumps({"schema_version": 1}), encoding="utf-8")  # lands now
+            return result
+
+        monkeypatch.setattr(auth_module, "read_vouched_stream_jar", read_then_commit)
+        resolver, patcher = self._resolver()
+        try:
+            first = resolver._get_ydl()
+            resolver._active_resolves -= 1
+            assert resolver._ydl_cookiejar_sig == snapshots[0]
+            monkeypatch.setattr(auth_module, "read_vouched_stream_jar", real_read)
+            second = resolver._get_ydl()
+        finally:
+            patcher.stop()
+        assert self._loaded(first) == self.JAR
+        assert second is not first
+        assert self._loaded(second) is None


### PR DESCRIPTION
## What

The sign-in files (`auth.json`, `account.json`, the stream cookie file) are now updated as one guarded transaction.

- `auth.json` is replaced atomically through an exclusive temp file; `account.json` is written for exactly those bytes, with a fresh revision and the hash of the stream cookie file published just before it.
- Every write runs under a per-path lock that is exclusive across threads and processes (`auth.json.lock`, never unlinked). An automatic renewal takes one snapshot at entry and only commits while the files still match it, so a newer `ytm setup` is never overwritten or rolled back. The cookies-file source no longer backs up, validates and restores.
- Readers never wait for the lock. A pair that is mid-replacement raises `SessionBusyError`; a record that exists but can't be read raises `SessionUnreadableError`. Both are `RuntimeError`s, never `OSError`, so no fallback builds a client from them. A record left behind by a crash between the writes yields the same unbound, working session a record-less install has today; `ytm setup` is the recovery. Nothing invents an identity.
- With `[yt_dlp] use_session_cookies` on, the resolver loads the stream cookie file only when the record for the current `auth.json` vouches for its exact bytes. The cached signature covers all three files and is the one of the snapshot that was checked. Installs that haven't committed since upgrading keep today's trust until their first commit, which publishes a strict record before any new file (a provisional, null-vouching one on a fresh install or over an invalid record).
- `ytm setup --manual` probes and commits the same bytes, keeps the existing record until the pasted headers are accepted, records a session it couldn't verify as unverified, and refuses to write through a symlink at `auth.json`. `ytm setup` says when ytm is running and needs a restart.

## Tests

New: `tests/test_services/test_auth_transactions.py`, `tests/test_services/test_auth_lock_process.py` (child process holds the lock; pipe-synchronised, no timing assertions), `TestStreamCookiejarVouching` in `test_stream_resolver_internals.py`, `tests/test_cli/test_setup_command.py`. Existing assertions that changed are the backup/restore, in-place-write and path-based jar-load behaviours this replaces; the three `_restore_or_remove` tests are gone with the method.

Draft until CI has run on this head across the full matrix. Windows exercises the `msvcrt.locking` backend for the first time here.
