### PR TITLE
fix(packaging): exclude local review files and check distribution contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,10 @@ pr*-changelog-diff.html
 *-ux-mockup.html
 broad-except-audit.local.md
 
+# Local-only notes. Also keeps them out of hatchling builds, which read
+# .gitignore but not .git/info/exclude.
+*.local.md
+
 # Local website-brainstorm scratch (not part of the package)
 .superpowers/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 **Fixes**
 
+- **The source distribution is an explicit allowlist** — `src/ytm_player`, `tests`, `docs`, `scripts`, `.github/scripts`, `aur` and the top-level documents, plus what hatchling always adds (`pyproject.toml`, `README.md`, `LICENSE`, `.gitignore`); `*.local.md` is ignored everywhere. Local notes and other files outside those paths stay out of a locally built archive, and a packaging test reports any other untracked file a build from the checkout would include.
 - **Sign-in files are updated in one guarded step** — `auth.json` is replaced atomically, its account record is written for exactly those bytes, and an automatic renewal only replaces the session it started from: a newer `ytm setup` is never overwritten or rolled back by a renewal, and two `ytm` processes can no longer update the sign-in at the same time. A crash between the writes leaves a working session that needs `ytm setup` to renew automatically again, never a truncated file.
 - **Stream cookies are used only when they belong to the current sign-in** — with `[yt_dlp] use_session_cookies` on, the saved stream cookie file is loaded only if the sign-in record vouches for it; otherwise streaming continues without session cookies and the log says to run `ytm setup`.
 - **`ytm setup --manual` keeps the existing account record until the pasted headers are accepted**, records a pasted session it could not verify as such, and refuses to write through a symlink at `auth.json`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,9 +14,10 @@ The release flow is **tag-driven**. Pushing a `vX.Y.Z` tag triggers PyPI publish
    .venv/bin/ruff check src/ tests/
    .venv/bin/pytest -x -q
    ```
-4. **Commit + tag + push**:
+4. **Commit + tag + push** — stage the release files explicitly and review the complete staged diff before committing:
    ```bash
-   git add -A
+   git add src/ytm_player/__init__.py CHANGELOG.md
+   git diff --cached
    git commit -m "chore(release): vX.Y.Z"
    git tag vX.Y.Z
    git push origin master --tags
@@ -39,6 +40,12 @@ No API tokens — auth is via OIDC trusted-publisher entries at PyPI and TestPyP
 Triggered after `Publish` succeeds. Checks out the exact commit the `Publish` run built (the one the tag guard verified), reads the version from `__version__` in `src/ytm_player/__init__.py`, clones `ssh://aur@aur.archlinux.org/ytm-player-git.git` via SSH key, copies `PKGBUILD`, rewrites its `pkgver=` line to the real version (the committed `pkgver=` is only a placeholder), regenerates `.SRCINFO` via `scripts/regenerate_srcinfo.py` (pure Python — no Arch dependency on Ubuntu CI runners), commits and pushes.
 
 The `regenerate_srcinfo.py` script handles shell variable expansion (`${url}`, `$pkgname`) so PKGBUILD constructs like `source=("git+${url}.git")` resolve correctly in the emitted `.SRCINFO`.
+
+## Local builds
+
+PyPI and GitHub Release artifacts are built only by `publish.yml` from a clean checkout. Never upload a locally built `dist/`.
+
+hatchling packages from the working tree and ignores `.git/info/exclude`. The sdist is an explicit allowlist (`[tool.hatch.build.targets.sdist]` in `pyproject.toml`) and `*.local.md` is in `.gitignore`, which keeps the known private-file locations out of a local build. Any other untracked file inside the allowlisted directories would still be packaged: `pytest tests/test_packaging` reports such files before anything is archived. Review them; stage intended project files explicitly, or exclude private files.
 
 ## Manual fallback (if AUR action fails)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["hatchling"]
+# 1.14.1 is the oldest release verified to build this project with the sdist allowlist below.
+requires = ["hatchling>=1.14"]
 build-backend = "hatchling.build"
 
 [project]
@@ -81,6 +82,7 @@ dev = [
     "anyascii>=0.3.0",
     "pre-commit>=4.6",
     "pyright>=1.1",
+    "hatchling>=1.14",  # tests/test_packaging inspects and builds distributions
 ]
 
 [project.urls]
@@ -93,6 +95,23 @@ Changelog = "https://github.com/peternaame-boop/ytm-player/blob/master/CHANGELOG
 
 [project.scripts]
 ytm = "ytm_player.cli:main"
+
+# hatchling packages from the working tree: it honours .gitignore but not
+# .git/info/exclude or the git index. Listing the sdist explicitly keeps local
+# notes and other files outside these paths out of a locally built archive;
+# tests/test_packaging reports untracked files inside them.
+[tool.hatch.build.targets.sdist]
+only-include = [
+    "src/ytm_player",
+    "tests",
+    "docs",
+    "scripts",
+    ".github/scripts",
+    "aur",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "SECURITY.md",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/ytm_player"]

--- a/tests/test_packaging/test_dist_contents.py
+++ b/tests/test_packaging/test_dist_contents.py
@@ -1,0 +1,205 @@
+"""Packaging safeguards.
+
+hatchling selects archive members from the working tree: it honours
+``.gitignore`` but reads neither ``.git/info/exclude`` nor the git index, so an
+untracked file would be packaged. The sdist is therefore an explicit allowlist
+and ``*.local.md`` is ignored, which keeps the known private-file locations out
+of a local build. These tests check that configuration and report any other
+untracked inclusion from the file selection alone: this checkout is never
+archived, and the only archives built here come from a synthetic tree.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tarfile
+import zipfile
+from pathlib import Path, PurePath
+
+import pytest
+
+hatchling_build = pytest.importorskip("hatchling.build")
+from hatchling.builders.plugin.interface import IncludedFile  # noqa: E402
+from hatchling.builders.sdist import SdistBuilder  # noqa: E402
+from hatchling.builders.wheel import WheelBuilder  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Without these the sdist could not build, install or run its own tests.
+REQUIRED_SDIST_FILES = (
+    "src/ytm_player/__init__.py",
+    "tests/conftest.py",
+    "docs/installation.md",
+    ".github/scripts/extract_changelog.py",
+    "scripts/regenerate_srcinfo.py",
+    "aur/PKGBUILD",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "SECURITY.md",
+)
+
+# Files hatchling adds to every sdist on its own when they exist at the root.
+AUTOMATIC_SDIST_FILES = ("pyproject.toml", ".gitignore", "README.md", "LICENSE")
+
+# Names modelled on real local notes and scratch files; the contents are synthetic.
+PRIVATE_FILES = (
+    "REVIEW-TASKS.local.md",
+    "HANDOFF.local.md",
+    "CODE-REVIEW-2026-01-01.md",
+    ".env",
+    "probes/repro_private.py",
+    "docs/private-notes.local.md",
+    "src/ytm_player/notes.local.md",
+    "tests/fixtures.local.md",
+    "reasoning/notes.md",
+    "headers.txt",
+)
+
+
+def _posix(relative_path: str) -> str:
+    """Native separators become ``/``; hatchling's empty sentinel for external files stays."""
+    return PurePath(relative_path).as_posix() if relative_path else ""
+
+
+def _selected(builder_cls: type, root: Path) -> set[str]:
+    """POSIX-form relative paths *builder_cls* would package from *root*.
+
+    Mirrors the start of ``BuilderInterface.build``: the builder's default build
+    data is applied so that automatic inclusions (``pyproject.toml``, the readme
+    and license files, ``.gitignore``, a root ``hatch_build.py``) are enumerated
+    as well, but no build hook runs and nothing is archived. Configuration and
+    project metadata are read as for any build; the selected payloads are not.
+    Generated archive metadata (``PKG-INFO``, the wheel ``.dist-info``) is not a
+    project file and never appears here.
+    """
+    builder = builder_cls(str(root))
+    build_data = builder.get_default_build_data()
+    builder.set_build_data_defaults(build_data)
+    with builder.config.set_build_data(build_data):
+        return {_posix(file.relative_path) for file in builder.recurse_included_files()}
+
+
+def _unexpected(root: Path, tracked: set[str]) -> list[str]:
+    """Paths the sdist or wheel would package from *root* that are not in *tracked*."""
+    selected = _selected(SdistBuilder, root) | _selected(WheelBuilder, root)
+    return sorted(selected - tracked)
+
+
+def _git_tracked(root: Path) -> set[str]:
+    def git(*args: str) -> str:
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(root), *args], capture_output=True, check=True
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            pytest.skip(f"not a git checkout: {exc}")
+        return result.stdout.decode("utf-8")
+
+    toplevel = Path(git("rev-parse", "--show-toplevel").strip())
+    if toplevel.resolve() != root.resolve():
+        pytest.skip(f"{root} is not the root of a git checkout (found {toplevel})")
+    return {name for name in git("ls-files", "-z").split("\0") if name}
+
+
+def _synthetic_project(tmp_path: Path) -> tuple[Path, tuple[str, ...], tuple[str, ...]]:
+    """A tree that uses this checkout's packaging config, with synthetic private files.
+
+    Returns the root, the stub files inside the allowlist and the stubs outside it.
+    """
+    project = tmp_path / "project"
+    allowlisted = (
+        "src/ytm_player/__init__.py",
+        "tests/conftest.py",
+        "docs/index.md",
+        "scripts/tool.py",
+        ".github/scripts/tool.py",
+        "aur/PKGBUILD",
+        "CHANGELOG.md",
+        "CONTRIBUTING.md",
+        "SECURITY.md",
+    )
+    outside_allowlist = ("CLAUDE.md", ".github/workflows/ci.yml")
+    contents = {rel: "" for rel in allowlisted + outside_allowlist}
+    contents["src/ytm_player/__init__.py"] = '__version__ = "0.0.0"\n'
+    contents["README.md"] = "# stub\n"
+    contents["LICENSE"] = "stub\n"
+    for name in ("pyproject.toml", ".gitignore"):
+        contents[name] = (REPO_ROOT / name).read_text(encoding="utf-8")
+    for rel in PRIVATE_FILES:
+        contents[rel] = "synthetic private content\n"
+    for rel, text in contents.items():
+        target = project / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+    return project, allowlisted, outside_allowlist
+
+
+def test_checkout_selection_contains_only_tracked_files():
+    unexpected = _unexpected(REPO_ROOT, _git_tracked(REPO_ROOT))
+    assert not unexpected, (
+        "files git does not track would be packaged: " + ", ".join(unexpected) + ". "
+        "Review them; stage intended project files explicitly, or exclude private files."
+    )
+
+
+def test_sdist_selection_covers_required_files():
+    selected = _selected(SdistBuilder, REPO_ROOT)
+    missing = sorted(set(REQUIRED_SDIST_FILES + AUTOMATIC_SDIST_FILES) - selected)
+    assert not missing, f"required files are not selected for the sdist: {missing}"
+
+
+def test_selection_paths_use_posix_separators(monkeypatch):
+    native = os.path.join("src", "pkg", "mod.py")
+    files = [
+        IncludedFile(str(REPO_ROOT / native), native, native),
+        IncludedFile(str(REPO_ROOT.parent / "external.txt"), "", "external.txt"),
+    ]
+    literal = "odd\\name.py"  # on POSIX a backslash is part of the name, not a separator
+    if os.name != "nt":
+        files.append(IncludedFile(str(REPO_ROOT / literal), literal, literal))
+    monkeypatch.setattr(SdistBuilder, "recurse_included_files", lambda self: iter(files))
+
+    selected = _selected(SdistBuilder, REPO_ROOT)
+
+    assert "src/pkg/mod.py" in selected
+    assert "" in selected
+    if os.name != "nt":
+        assert literal in selected
+
+
+def test_automatic_inclusions_are_reported(tmp_path):
+    project, allowlisted, _ = _synthetic_project(tmp_path)
+    (project / "hatch_build.py").write_text("# synthetic, never executed\n", encoding="utf-8")
+    tracked = {*allowlisted, *AUTOMATIC_SDIST_FILES}
+
+    selected = _selected(SdistBuilder, project)
+
+    assert set(AUTOMATIC_SDIST_FILES) <= selected
+    assert "PKG-INFO" not in selected
+    assert _unexpected(project, tracked) == ["hatch_build.py"]
+
+
+def test_synthetic_build_excludes_private_files(tmp_path, monkeypatch):
+    """Build archives from a synthetic tree that uses this checkout's packaging config."""
+    project, allowlisted, outside_allowlist = _synthetic_project(tmp_path)
+    out = tmp_path / "dist"
+    out.mkdir()
+    monkeypatch.chdir(project)
+    sdist_name = hatchling_build.build_sdist(str(out))
+    wheel_name = hatchling_build.build_wheel(str(out))
+    with tarfile.open(out / sdist_name) as tar:
+        sdist = {
+            member.name.split("/", 1)[1]
+            for member in tar.getmembers()
+            if member.isfile() and "/" in member.name
+        }
+    with zipfile.ZipFile(out / wheel_name) as archive:
+        wheel = set(archive.namelist())
+
+    assert not set(PRIVATE_FILES) & sdist
+    assert not {name for name in sdist | wheel if name.endswith(".local.md")}
+    assert not set(outside_allowlist) & sdist
+    assert {*AUTOMATIC_SDIST_FILES, *allowlisted} <= sdist
+    assert all(name.startswith(("ytm_player/", "ytm_player-")) for name in wheel)
+    assert "ytm_player/__init__.py" in wheel


### PR DESCRIPTION
hatchling packages from the working tree: it honours `.gitignore` but reads neither `.git/info/exclude` nor the git index. A local `python -m build` therefore archived files I keep out of git only locally (`*.local.md` review notes) and any other untracked file. Reproduced in a scratch clone with synthetic files: 8 of 10 planted files entered the sdist and one entered the wheel. The published PyPI sdists are clean, since `publish.yml` builds from a fresh checkout; the exposure is a local build.

**Changes**

- `pyproject.toml`: the sdist is an explicit allowlist (`src/ytm_player`, `tests`, `docs`, `scripts`, `.github/scripts`, `aur`, the top-level documents, plus what hatchling always adds). `scripts`, `.github/scripts` and `aur` stay in because `tests/test_scripts` needs them. Build-system and dev floor `hatchling>=1.14`, the oldest release verified to build this project.
- `.gitignore`: `*.local.md`, which hatchling honours everywhere, including inside the package.
- `tests/test_packaging/test_dist_contents.py`: the file selection hatchling would package must be git tracked, checked from the selection alone so the checkout is never archived; the required files stay selected; a synthetic tree proves private files are excluded and that automatic inclusions such as a root `hatch_build.py` are reported. Native separators are normalised, so the tests are meant to run on Windows.
- `RELEASING.md`: explicit paths instead of `git add -A`, a staged-diff review before the release commit, and a note that release artifacts come only from CI.

What this does not do: an untracked file inside an allowlisted directory still ships from a local build. The new test reports it; it does not prevent it.

**Verification**

- Wheel payload byte-identical to master; only the dev `Requires-Dist` line in METADATA changes.
- Full suite from the extracted sdist passes with the git-only test skipped.
- hatchling 1.14.1, 1.18, 1.21, 1.24, 1.26, 1.27 and 1.32 produce the same member sets.
