### PR TITLE
fix(recently-played): keep marks on repeated history rows and make blank-strip clicks row clicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 **Fixes**
 
+- **Recently Played: marks and the cursor survive on the YT Music tab** — the account feed lists a track on every day it was played, and those repeated rows made a play landing in the background drop the marks on that track and send the cursor to the top. Every row now keeps its own identity across the refresh; the rows themselves are unchanged. A play the account accepts moves the track's most recent row to the top and leaves its older rows where they are, until the next reload shows the account's own list.
+- **A click in the blank space right of the columns plays the row again** — since the mark column arrived, a plain click there marked the row instead. Ctrl+click and Shift+click there still mark.
 - **Turning shuffle off keeps the playing track** — after skipping under shuffle, turning shuffle off jumped the position back to the track that was playing when shuffle went on, so Next continued from the wrong place.
 - **The Queue page follows every queue change** — toggling shuffle (key, playback-bar button or Shuffle lock), `ytm queue clear`, `ytm queue add` and the background fill of a long playlist now re-render the page, so `d`, `J` and `K` act on the row you see instead of a row that was no longer there.
 - **Remove from Queue removes the copy you picked** — with the same song queued twice, the track menu removed the first copy whichever one was selected. It now removes that occurrence; if it was already gone when you confirmed, nothing else is removed.

--- a/src/ytm_player/app/_playback.py
+++ b/src/ytm_player/app/_playback.py
@@ -942,14 +942,23 @@ class PlaybackMixin(YTMHostBase):
         """Reflect a play the account just accepted in the cached account history.
 
         Runs only after ``add_history_item`` succeeded, so the YT Music and
-        All tabs agree with the account. With a feed cached, the play moves
-        to the top. With none cached (first visit still pending, or a
-        refresh in flight) it is parked in ``_ytm_history_pending`` with a
-        sequence number, so the next fetch can tell whether the play came
-        before or after the feed it received (see the page's
-        ``_merge_pending_account_plays``). Re-renders the page when the YT
-        Music or All tab is showing.
+        All tabs agree with the account. With a feed cached, the play
+        supersedes the track's most recent row, which moves to the top
+        keeping its identity; older rows of the track stay (see the page's
+        ``_with_accepted_play``). That is a provisional view: the next
+        fetch is authoritative. With none cached (first visit still
+        pending, or a refresh in flight) it is parked in
+        ``_ytm_history_pending`` with a sequence number, so the next fetch
+        can tell whether the play came before or after the feed it received
+        (see the page's ``_merge_pending_account_plays``). Re-renders the
+        page when the YT Music or All tab is showing.
         """
+        from ytm_player.ui.pages.recently_played import (
+            _TAB_YTM,
+            RecentlyPlayedPage,
+            _with_accepted_play,
+        )
+
         video_id = get_video_id(track)
         if not video_id:
             return
@@ -962,9 +971,7 @@ class PlaybackMixin(YTMHostBase):
             ]
             del pending[_YTM_PENDING_MAX:]
             return
-        self._ytm_history = [dict(track)] + [t for t in cache if get_video_id(t) != video_id]
-
-        from ytm_player.ui.pages.recently_played import _TAB_YTM, RecentlyPlayedPage
+        self._ytm_history = _with_accepted_play(cache, track)
 
         page = self._get_current_page()
         if isinstance(page, RecentlyPlayedPage):

--- a/src/ytm_player/ui/pages/recently_played.py
+++ b/src/ytm_player/ui/pages/recently_played.py
@@ -17,8 +17,10 @@ Three tabs:
 from __future__ import annotations
 
 import asyncio
+import itertools
 import logging
 import sqlite3
+from collections.abc import Hashable
 from typing import TYPE_CHECKING, Any, cast
 
 from textual.app import ComposeResult
@@ -72,6 +74,51 @@ _TAB_DESCRIPTIONS = {
 # cap when it derives its rows, so All shows up to 100 local rows plus up to
 # 100 further account rows.
 _MAX_TRACKS = 100
+
+
+# Occurrence ids for the rows of the account cache. The feed lists a track
+# once per day it was played, so the same video ID can name several rows;
+# each row gets its own id when it enters the cache and keeps it while it
+# stays, which is what a keyed refresh of the YT Music tab matches on.
+_occurrences = itertools.count(1)
+
+
+def _stamp(track: dict, occurrence: int | None = None) -> dict:
+    """A copy of *track* carrying an occurrence id (a fresh one unless given)."""
+    stamped = dict(track)
+    stamped["_occurrence"] = next(_occurrences) if occurrence is None else occurrence
+    return stamped
+
+
+def _occurrence_key(track: dict) -> Hashable:
+    """The key a cached account row is matched by across background refreshes.
+
+    Every row the cache holds is stamped; one that reached it another way
+    falls back to its video ID.
+    """
+    return track.get("_occurrence", get_video_id(track))
+
+
+def _with_accepted_play(cache: list[dict], track: dict) -> list[dict]:
+    """*cache* with an accepted play of *track* on top.
+
+    The play supersedes the track's most recent listing: that row moves to
+    the top keeping its identity (a mark on it moves along) and takes the
+    played track's details. Older listings of the track stay where they
+    are — a play never deletes history. A track the cache does not list
+    gets a new occurrence. Identity is the cache's to decide: a stamp the
+    incoming *track* carries (a row it was played from) is never kept.
+
+    This is a provisional update of the cached view, not a reconstruction
+    of the server's per-day shelves; the next fetch replaces the cache
+    with the server's list, which is authoritative.
+    """
+    video_id = get_video_id(track)
+    for index, cached in enumerate(cache):
+        if get_video_id(cached) == video_id:
+            moved = _stamp(track, cached.get("_occurrence"))
+            return [moved] + cache[:index] + cache[index + 1 :]
+    return [_stamp(track)] + list(cache)
 
 
 def _enrich(track: dict, extra: dict) -> dict:
@@ -344,10 +391,12 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
     async def _fetch_ytm(self) -> None:
         """Fill the app-level account cache from ``get_history()``; renders nothing.
 
-        The cache holds the whole normalized feed, unfiltered; views apply
-        their own limits. Plays the account accepted while no feed was
-        cached (see ``_add_to_ytm_history_cache`` on the app) are folded
-        into the fetched feed by ``_merge_pending_account_plays``.
+        The cache holds the whole normalized feed, unfiltered, every row
+        stamped with its occurrence id (the feed lists a track once per day
+        it was played; ``normalize_tracks`` drops the day, the rows stay);
+        views apply their own limits. Plays the account accepted while no
+        feed was cached (see ``_add_to_ytm_history_cache`` on the app) are
+        folded into the fetched feed by ``_merge_pending_account_plays``.
         """
         self._ytm_auth_required = False
         self._ytm_load_failed = False
@@ -365,9 +414,8 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
         if raw is None:
             self._ytm_load_failed = True
             return
-        self._set_cache(
-            _TAB_YTM, self._merge_pending_account_plays(normalize_tracks(raw), fetch_seq)
-        )
+        feed = [_stamp(track) for track in normalize_tracks(raw)]
+        self._set_cache(_TAB_YTM, self._merge_pending_account_plays(feed, fetch_seq))
 
     def _pending_account_seq(self) -> int:
         """The sequence number of the latest pending accepted play (0 = none yet)."""
@@ -378,20 +426,24 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
         """Fold the pending accepted plays into *feed*, consuming them.
 
         A play accepted after the fetch started (sequence number above
-        *fetch_seq*) post-dates the feed, so it goes ahead of it even when
-        the feed already lists the track. A play accepted before the fetch
-        started is already reflected in the feed: its server position
-        stands. Only when the feed does not list such a play yet does it go
-        ahead of the feed, behind the newer plays.
+        *fetch_seq*) post-dates the feed, so it goes ahead of it, superseding
+        the feed's most recent listing of the track if there is one (see
+        ``_with_accepted_play``). A play accepted before the fetch started
+        is already reflected in the feed: its server position stands. Only
+        when the feed does not list such a play yet does it go ahead of the
+        feed, behind the newer plays.
         """
         pending = self._take_pending_account_plays()
         if not pending:
             return feed
         feed_ids = {get_video_id(t) for t in feed}
-        ahead = [t for seq, t in pending if seq > fetch_seq]
-        ahead += [t for seq, t in pending if seq <= fetch_seq and get_video_id(t) not in feed_ids]
-        ahead_ids = {get_video_id(t) for t in ahead}
-        return ahead + [t for t in feed if get_video_id(t) not in ahead_ids]
+        merged = list(feed)
+        # Oldest first, so the newest play ends up on top.
+        for seq, track in reversed(pending):
+            if seq <= fetch_seq and get_video_id(track) in feed_ids:
+                continue
+            merged = _with_accepted_play(merged, track)
+        return merged
 
     def _take_pending_account_plays(self) -> list[tuple[int, dict]]:
         pending = getattr(self.app, "_ytm_history_pending", None)
@@ -436,18 +488,21 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
     def optimistic_add(self, index: int, track: dict) -> None:
         """Prepend a just-played track to a source's cache and re-render live.
 
-        Dedups by ``video_id``: an existing row for the same track moves to
-        the top. The Local cache stays capped at ``_MAX_TRACKS`` (its query
-        limit); the account cache is unfiltered and capped on display. No-op
-        until the source has a cache (the first visit fetches the real list).
-        If the source, or All, is showing, it re-renders.
+        Local lists a track once (its query groups by track): an existing
+        row for the same track moves to the top, and the cache stays capped
+        at ``_MAX_TRACKS`` (its query limit). The account cache keeps every
+        listing (see ``_with_accepted_play``) and is capped on display.
+        No-op until the source has a cache (the first visit fetches the
+        real list). If the source, or All, is showing, it re-renders.
         """
         cache = self._get_cache(index)
         if cache is None:
             return
-        video_id = get_video_id(track)
-        updated = [dict(track)] + [t for t in cache if get_video_id(t) != video_id]
-        if index == _TAB_LOCAL:
+        if index == _TAB_YTM:
+            updated = _with_accepted_play(cache, track)
+        else:
+            video_id = get_video_id(track)
+            updated = [dict(track)] + [t for t in cache if get_video_id(t) != video_id]
             updated = updated[:_MAX_TRACKS]
         self._set_cache(index, updated)
         self._refresh_tab_from_cache(index)
@@ -459,8 +514,8 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
         draws from both sources). Never steals focus: the change lands from
         playback timers, not user input, and the user may be typing in the
         filter. The table keeps its view across the re-render — sort,
-        filter, cursor and marks — matching rows by video ID, which every
-        view shows once.
+        filter, cursor and marks — matching rows by the keys
+        ``_display_tracks`` loads them with.
         """
         if self._active_tab not in (index, _TAB_ALL):
             return
@@ -488,10 +543,15 @@ class RecentlyPlayedPage(TrackFilterHost, Widget):
 
         loading.display = False
         table.display = True
-        # Every load is keyed by video ID (each view shows a track once) so
-        # a later background refresh can carry the marks over; a deliberate
-        # load still starts with none.
-        keys = [get_video_id(t) for t in tracks]
+        # Every load is keyed so a later background refresh can carry the
+        # marks over: by video ID where the view shows a track once (All,
+        # Local), by occurrence on the YT Music tab, which lists a track
+        # once per day it was played. A deliberate load still starts with
+        # no marks.
+        if self._active_tab == _TAB_YTM:
+            keys: list[Hashable] = [_occurrence_key(t) for t in tracks]
+        else:
+            keys = [get_video_id(t) for t in tracks]
         if refresh:
             table.refresh_tracks(tracks, keys=keys)
         else:

--- a/src/ytm_player/ui/widgets/track_table.py
+++ b/src/ytm_player/ui/widgets/track_table.py
@@ -1041,7 +1041,10 @@ class TrackTable(DataTable):
             row_idx = meta.get("row") if meta else None
             if row_idx is None or not (0 <= row_idx < len(self._tracks)):
                 return
-            on_mark_column = meta.get("column") == 0
+            # DataTable tags the filler right of the last column as column 0
+            # "out of bounds"; a plain click there is a row click, not a
+            # click on the mark column.
+            on_mark_column = meta.get("column") == 0 and not meta.get("out_of_bounds")
             if not (event.ctrl or event.shift or on_mark_column):
                 return
             event.stop()

--- a/tests/test_app/test_ytm_history_report.py
+++ b/tests/test_app/test_ytm_history_report.py
@@ -71,6 +71,11 @@ def _report(host, video_id="vid1", generation=1) -> None:
     PlaybackMixin._report_ytm_play.__get__(host)(track, video_id, generation)
 
 
+def _without_occurrence(rows: list[dict]) -> list[dict]:
+    """*rows* minus the occurrence id the account cache stamps on them."""
+    return [{k: v for k, v in row.items() if k != "_occurrence"} for row in rows]
+
+
 def _claim(video_id: str = "vid1", generation: int = 1, **kw) -> _LocalHistoryClaim:
     c = _LocalHistoryClaim(video_id=video_id, track={"video_id": video_id}, generation=generation)
     for k, v in kw.items():
@@ -321,7 +326,10 @@ async def test_push_adds_the_accepted_play_to_the_account_cache() -> None:
 
     host.ytmusic.add_history_item.assert_awaited_once_with("vid1")
     assert host._ytm_reported_generation == 3
-    assert host._ytm_history == [{"video_id": "vid1", "title": "Fresh"}, {"video_id": "old"}]
+    assert _without_occurrence(host._ytm_history) == [
+        {"video_id": "vid1", "title": "Fresh"},
+        {"video_id": "old"},
+    ]
     assert host._ytm_history_pending == []
 
 
@@ -645,7 +653,10 @@ def test_ytm_cache_update_moves_the_play_to_the_top() -> None:
 
     PlaybackMixin._add_to_ytm_history_cache.__get__(host)({"video_id": "vid1", "title": "new"})
 
-    assert host._ytm_history == [{"video_id": "vid1", "title": "new"}, {"video_id": "a"}]
+    assert _without_occurrence(host._ytm_history) == [
+        {"video_id": "vid1", "title": "new"},
+        {"video_id": "a"},
+    ]
 
 
 def test_ytm_cache_update_rerenders_the_open_page() -> None:

--- a/tests/test_ui/test_recently_played_marks.py
+++ b/tests/test_ui/test_recently_played_marks.py
@@ -1,9 +1,11 @@
 """Marks on the real Recently Played page survive the plays that re-render it.
 
-Every load of the page's table is keyed by video ID, so the first
-background refresh after marking (a play landing) carries the marks over
-instead of falling back to a fresh load. A deliberate load still starts
-with none.
+These tests drive the Local tab, which lists a track once, so every load
+of its table is keyed by video ID and the first background refresh after
+marking (a play landing) carries the marks over instead of falling back
+to a fresh load. A deliberate load still starts with none. The YT Music
+tab, whose rows are keyed by occurrence, is covered in
+``test_recently_played_ytm_occurrences.py``.
 """
 
 from __future__ import annotations

--- a/tests/test_ui/test_recently_played_ytm_occurrences.py
+++ b/tests/test_ui/test_recently_played_ytm_occurrences.py
@@ -1,0 +1,246 @@
+"""The YT Music tab's rows keep their identity across background refreshes.
+
+``get_history()`` lists a track once per day it was played, so the account
+feed can name one video ID on several rows. Each row of the account cache
+carries its own occurrence id from the moment it enters the cache, and the
+YT Music tab keys its loads by it, so a play landing in the background
+(a keyed refresh) carries every mark and the cursor over. Repeated rows
+stay: a play the account accepts supersedes only the track's most recent
+row, which keeps its identity and moves to the top; older rows are left
+where they are. That is a provisional view of the cache — the next fetch
+replaces it with the server's list.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from textual.app import App, ComposeResult
+
+from ytm_player.app._playback import PlaybackMixin
+from ytm_player.config.keymap import Action
+from ytm_player.ui.pages.recently_played import (
+    _TAB_YTM,
+    RecentlyPlayedPage,
+    _occurrence_key,
+    _stamp,
+    _with_accepted_play,
+)
+from ytm_player.ui.widgets.track_table import TrackTable
+
+
+def _raw(video_id: str, title: str, played: str) -> dict:
+    return {
+        "videoId": video_id,
+        "title": title,
+        "artists": [{"name": "X", "id": "1"}],
+        "played": played,
+    }
+
+
+# One shelf per day: Song A was played today and yesterday, so it comes
+# back twice. normalize_tracks() drops "played"; the rows remain.
+FEED = [
+    _raw("bbb", "Song B", "Today"),
+    _raw("aaa", "Song A", "Today"),
+    _raw("aaa", "Song A", "Yesterday"),
+    _raw("ccc", "Song C", "Yesterday"),
+]
+
+
+class _Host(App):
+    """Minimal host exposing the attributes RecentlyPlayedPage reads."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.history = MagicMock()
+        self.history.get_recently_played = AsyncMock(return_value=[])
+        self.ytmusic = MagicMock()
+        self.ytmusic.get_history = AsyncMock(return_value=FEED)
+        self._ytm_history = None
+        self._ytm_history_pending = []
+        self._ytm_history_pending_seq = 0
+
+    def get_css_variables(self) -> dict[str, str]:
+        variables = super().get_css_variables()
+        variables["selected-item"] = "#3a3a3a"
+        return variables
+
+    def compose(self) -> ComposeResult:
+        yield RecentlyPlayedPage(id="page", active_tab=_TAB_YTM)
+
+    def _get_current_page(self):
+        return self.query_one("#page", RecentlyPlayedPage)
+
+
+def _glyphs(table: TrackTable) -> str:
+    return "".join(str(table.get_row_at(i)[0]) for i in range(table.row_count))
+
+
+def _ids(table: TrackTable) -> list[str]:
+    return [t["video_id"] for t in table.visible_tracks]
+
+
+def _keys(table: TrackTable) -> list:
+    return [table.occurrence_key(i) for i in range(table.row_count)]
+
+
+def _accept(host: _Host, track: dict) -> None:
+    """The account accepted a play of *track* (the app's cache update)."""
+    PlaybackMixin._add_to_ytm_history_cache.__get__(host)(track)
+
+
+async def _loaded(host: _Host, pilot) -> tuple[RecentlyPlayedPage, TrackTable]:
+    await host.workers.wait_for_complete()
+    await pilot.pause()
+    page = host.query_one("#page", RecentlyPlayedPage)
+    table = page.query_one("#recent-table", TrackTable)
+    table.focus()
+    return page, table
+
+
+async def _mark(page: RecentlyPlayedPage, table: TrackTable, *rows: int) -> None:
+    for row in rows:
+        table.move_cursor(row=row)
+        await page.handle_action(Action.MARK_TOGGLE)
+
+
+# ── The page ──────────────────────────────────────────────────────────
+
+
+async def test_repeated_rows_stay_and_each_has_its_own_key():
+    host = _Host()
+    async with host.run_test(size=(100, 24)) as pilot:
+        _page, table = await _loaded(host, pilot)
+        assert _ids(table) == ["bbb", "aaa", "aaa", "ccc"]
+        assert len(set(_keys(table))) == 4
+
+
+async def test_marks_on_both_rows_of_a_track_and_the_cursor_survive_a_play_landing():
+    host = _Host()
+    async with host.run_test(size=(100, 24)) as pilot:
+        page, table = await _loaded(host, pilot)
+        await _mark(page, table, 0, 1, 2)  # Song B, Song A (today), Song A (yesterday)
+        table.move_cursor(row=2)  # the second Song A
+        keys = _keys(table)
+
+        _accept(host, {"video_id": "zzz", "title": "Just played"})
+        await pilot.pause()
+
+        assert _ids(table) == ["zzz", "bbb", "aaa", "aaa", "ccc"]
+        assert _glyphs(table) == " ✓✓✓ "
+        assert table.cursor_row == 3
+        assert _keys(table)[1:] == keys
+
+
+async def test_a_play_of_a_repeated_track_moves_its_latest_row_and_keeps_the_older_one():
+    host = _Host()
+    async with host.run_test(size=(100, 24)) as pilot:
+        page, table = await _loaded(host, pilot)
+        await _mark(page, table, 1, 2)  # both Song A rows
+        latest, older = _keys(table)[1], _keys(table)[2]
+
+        _accept(host, {"video_id": "aaa", "title": "Song A (replayed)"})
+        await pilot.pause()
+
+        assert _ids(table) == ["aaa", "bbb", "aaa", "ccc"]
+        assert table.visible_tracks[0]["title"] == "Song A (replayed)"
+        assert _keys(table)[0] == latest
+        assert _keys(table)[2] == older
+        assert _glyphs(table) == "✓ ✓ "  # each mark followed its own row
+
+
+async def test_a_play_from_an_older_row_still_supersedes_the_latest_one():
+    """The played track carries the stamp of the row it was played from (the
+    older Song A); the cache decides identity, not the incoming dict."""
+    host = _Host()
+    async with host.run_test(size=(100, 24)) as pilot:
+        page, table = await _loaded(host, pilot)
+        await _mark(page, table, 2)  # the older Song A
+        latest, older = _keys(table)[1], _keys(table)[2]
+        played = dict(table.visible_tracks[2])
+        assert played["_occurrence"] == older
+
+        _accept(host, played)
+        await pilot.pause()
+
+        assert _ids(table) == ["aaa", "bbb", "aaa", "ccc"]
+        assert _keys(table)[0] == latest
+        assert _keys(table)[2] == older
+        assert _glyphs(table) == "  ✓ "  # the mark stayed on the older row
+
+
+async def test_a_play_accepted_during_the_fetch_supersedes_one_row_only():
+    """Parked while the fetch ran, the play goes on top and supersedes the
+    feed's most recent Song A row; the older one stays."""
+    host = _Host()
+    release = asyncio.Event()
+
+    async def slow_history():
+        await release.wait()
+        return FEED
+
+    host.ytmusic.get_history = AsyncMock(side_effect=slow_history)
+    async with host.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        _accept(host, {"video_id": "aaa", "title": "Just played"})  # parked: no cache yet
+        assert host._ytm_history is None
+        release.set()
+        _page, table = await _loaded(host, pilot)
+
+        assert _ids(table) == ["aaa", "bbb", "aaa", "ccc"]
+        assert table.visible_tracks[0]["title"] == "Just played"
+        assert len(set(_keys(table))) == 4
+
+
+# ── The cache helpers ─────────────────────────────────────────────────
+
+
+def _cached(video_id: str, title: str) -> dict:
+    return _stamp({"video_id": video_id, "title": title})
+
+
+def test_every_stamp_is_distinct_and_the_key_is_the_stamp():
+    rows = [_cached("aaa", "A"), _cached("aaa", "A"), _cached("bbb", "B")]
+    keys = [_occurrence_key(row) for row in rows]
+    assert keys == [row["_occurrence"] for row in rows]
+    assert len(set(keys)) == 3
+
+
+def test_an_unstamped_row_is_keyed_by_its_video_id():
+    assert _occurrence_key({"video_id": "aaa"}) == "aaa"
+
+
+def test_a_play_supersedes_the_latest_row_of_the_track_only():
+    latest, older = _cached("aaa", "A"), _cached("aaa", "A")
+    cache = [_cached("bbb", "B"), latest, older]
+
+    updated = _with_accepted_play(cache, {"video_id": "aaa", "title": "A again"})
+
+    assert [row["video_id"] for row in updated] == ["aaa", "bbb", "aaa"]
+    assert updated[0]["title"] == "A again"
+    assert updated[0]["_occurrence"] == latest["_occurrence"]
+    assert updated[2] is older
+    assert cache == [cache[0], latest, older]  # the input is left alone
+
+
+def test_a_play_of_a_track_not_in_the_cache_gets_a_new_stamp():
+    cache = [_cached("bbb", "B")]
+
+    updated = _with_accepted_play(cache, {"video_id": "aaa", "title": "A"})
+
+    assert [row["video_id"] for row in updated] == ["aaa", "bbb"]
+    assert updated[0]["_occurrence"] not in {row["_occurrence"] for row in cache}
+
+
+def test_the_cache_decides_identity_not_the_incoming_track():
+    latest, older = _cached("aaa", "A"), _cached("aaa", "A")
+    stale = dict(older, title="played from the older row")
+
+    updated = _with_accepted_play([latest, older], stale)
+    assert updated[0]["_occurrence"] == latest["_occurrence"]
+    assert updated[1] is older
+
+    fresh = _with_accepted_play([], dict(older, title="cache emptied meanwhile"))
+    assert fresh[0]["_occurrence"] != older["_occurrence"]

--- a/tests/test_ui/test_track_table_marks.py
+++ b/tests/test_ui/test_track_table_marks.py
@@ -362,6 +362,56 @@ async def test_click_on_the_mark_column_toggles_without_selecting():
         assert app.selected == []
 
 
+async def _with_blank_strip(app: _Host, pilot) -> int:
+    """Load four rows, narrow the Title column, return an x inside the blank strip.
+
+    The user dragged the Title column narrower: auto-fill is off and a
+    blank strip opens right of the last column (the drag gesture's state).
+    DataTable tags a click there as column 0, out of bounds.
+    """
+    table = app.table
+    table.load_tracks(_unique_tracks())
+    await pilot.pause()
+    title = next(c for c in table.ordered_columns if c.key.value == "title")
+    title.width = 10
+    title.auto_width = False
+    table._title_manual_width = True
+    table._invalidate_table()
+    await pilot.pause()
+    used = table._row_label_column_width + sum(
+        c.get_render_width(table) for c in table.ordered_columns
+    )
+    assert used < table.size.width, "no blank strip"
+    return used + 2
+
+
+async def test_plain_click_in_the_blank_strip_is_a_row_click_not_a_mark():
+    app = _Host()
+    async with app.run_test(size=(120, 20)) as pilot:
+        table = app.table
+        x = await _with_blank_strip(app, pilot)
+
+        # Row 0 is highlighted after the load and the strip counts as column
+        # 0, so one click there lands on the cursor cell: it selects at once.
+        await pilot.click(TrackTable, offset=(x, 1))
+        await pilot.pause()
+        assert _glyphs(table) == "    "
+        assert table.marked_count == 0
+        assert app.selected == ["Alpha"]
+
+
+async def test_ctrl_click_in_the_blank_strip_still_marks_the_row():
+    app = _Host()
+    async with app.run_test(size=(120, 20)) as pilot:
+        table = app.table
+        x = await _with_blank_strip(app, pilot)
+
+        await pilot.click(TrackTable, offset=(x, 2), control=True)  # row 1
+        await pilot.pause()
+        assert _glyphs(table) == " ✓  "
+        assert app.selected == []
+
+
 async def test_plain_click_on_a_data_cell_still_selects():
     app = _Host()
     async with app.run_test() as pilot:


### PR DESCRIPTION
Fixes the history-occurrence and blank-area-click findings from the v2.1.0 review.

**Marks and the cursor survive on the YT Music tab.** The account feed lists a track on every day it was played, so one video id can name several rows. The tab keyed its rows by video id, and a play landing in the background could not resolve those repeated keys: the marks on that track were dropped and the cursor went to the top. Every row of the account cache now carries its own occurrence id from the moment it enters the cache, and the tab keys its loads by it. The rows themselves are unchanged: repeated history rows stay.

A play the account accepts moves the track's most recent row to the top, keeping its identity, and leaves the older rows where they are instead of removing them. The cache decides identity, never the incoming track. That is a provisional view of the cache; the next reload shows the account's own list.

**A click in the blank space right of the columns plays the row again.** DataTable tags that filler as column 0 "out of bounds", so since the mark column arrived a plain click there marked the row instead of selecting it. It is a row click again; Ctrl+click and Shift+click there still mark.

Regression tests cover repeated rows keeping distinct identities and marks across a play landing, a play accepted while the fetch was in flight, a play made from an older row, and both click cases on a table with a blank strip.
